### PR TITLE
feat: UI polish — update brand colors, simplify FAB, add tab tint

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -5,11 +5,12 @@ import {
   Badge,
 } from "expo-router/unstable-native-tabs";
 import { useNotifications } from "../../src/context/NotificationContext";
+import { colors } from "../../src/theme/colors";
 
 function TabLayout() {
   const { unreadCount } = useNotifications();
   return (
-    <NativeTabs>
+    <NativeTabs tintColor={colors.primary}>
       <NativeTabs.Trigger name="map">
         <Icon sf={{ default: "map", selected: "map.fill" }} />
         <Label>Map</Label>

--- a/claude.md
+++ b/claude.md
@@ -263,6 +263,15 @@ Supabase API layer. Each service handles CRUD operations for its domain:
 - `create-seed-users.mjs` - Script to create seed auth users
 - `run-sql.mjs` - Remote SQL execution helper
 
+## CI / Quality
+
+- **GitHub Actions** (`.github/workflows/ci.yml`) runs on push/PR to `main`: typecheck → lint → test
+- **TypeScript**: `npm run typecheck` (runs `tsc --noEmit`)
+- **ESLint**: `npm run lint` (runs `eslint .`) — uses `eslint-config-expo` flat config (`eslint.config.mjs`), ESLint v9
+- **Jest**: `npm test` (runs `jest --passWithNoTests`) — uses `jest-expo` preset, Jest v29
+- Tests live in `src/utils/__tests__/` — unit tests for utility functions
+- Install dependencies with `--legacy-peer-deps` flag (required due to peer dep conflicts)
+
 ## Key Patterns
 
 - **Shared screens across tabs**: `UserProfileScreen`, `FollowListScreen`, `DiscoverUsersScreen` use `usePathname()` to determine the current tab and build tab-relative paths (e.g. `/feed/user/123` vs `/map/user/123`)

--- a/src/components/FloatingCreateButton.tsx
+++ b/src/components/FloatingCreateButton.tsx
@@ -1,17 +1,10 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { StyleSheet, ViewStyle, View } from "react-native";
 import { useRouter, usePathname } from "expo-router";
 import { BlurView } from "expo-blur";
 import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withRepeat,
-  withSequence,
-  withTiming,
-  Easing,
-} from "react-native-reanimated";
+import Animated from "react-native-reanimated";
 import { SFIcon } from "./SFIcon";
 import { HapticPressable } from "./HapticPressable";
 import { colors } from "../theme/colors";
@@ -23,29 +16,13 @@ interface FloatingCreateButtonProps {
 }
 
 function AIIcon() {
-  const glow = useSharedValue(0.3);
-
-  useEffect(() => {
-    glow.value = withRepeat(
-      withSequence(
-        withTiming(0.8, { duration: 2000, easing: Easing.inOut(Easing.ease) }),
-        withTiming(0.3, { duration: 2000, easing: Easing.inOut(Easing.ease) }),
-      ),
-      -1,
-    );
-  }, [glow]);
-
-  const glowStyle = useAnimatedStyle(() => ({
-    shadowOpacity: glow.value,
-  }));
-
   return (
-    <Animated.View style={[aiStyles.iconWrap, glowStyle]}>
+    <Animated.View style={[aiStyles.iconWrap]}>
       <SFIcon
         name="sparkles"
         fallback="sparkles"
-        size={22}
-        color={colors.primary}
+        size={32}
+        color={colors.text}
       />
     </Animated.View>
   );
@@ -67,8 +44,8 @@ function Buttons() {
   const tabPrefix = pathname.startsWith("/feed")
     ? "/feed"
     : pathname.startsWith("/events")
-      ? "/events"
-      : "/map";
+    ? "/events"
+    : "/map";
 
   const handleCreate = () => {
     const defaultType = pathname.startsWith("/events") ? "event" : "post";
@@ -104,24 +81,14 @@ export function FloatingCreateButton({ style }: FloatingCreateButtonProps) {
   const insets = useSafeAreaInsets();
 
   return (
-    <View
-      style={[
-        styles.container,
-        { bottom: insets.bottom + 60 },
-        style,
-      ]}
-    >
+    <View style={[styles.container, { bottom: insets.bottom + 60 }, style]}>
       {glassEnabled ? (
         <GlassView style={styles.glass}>
           <Buttons />
         </GlassView>
       ) : (
         <View style={styles.blurContainer}>
-          <BlurView
-            intensity={10}
-            tint="light"
-            style={styles.blurBg}
-          />
+          <BlurView intensity={10} tint="light" style={styles.blurBg} />
           <View style={styles.blurInner}>
             <Buttons />
           </View>

--- a/src/components/SFIcon.tsx
+++ b/src/components/SFIcon.tsx
@@ -1,6 +1,6 @@
-import { Platform, StyleProp, ViewStyle } from 'react-native';
-import { SymbolView, SFSymbol, SymbolWeight } from 'expo-symbols';
-import { Ionicons } from '@expo/vector-icons';
+import { Platform, StyleProp, ViewStyle } from "react-native";
+import { SymbolView, SFSymbol, SymbolWeight } from "expo-symbols";
+import { Ionicons } from "@expo/vector-icons";
 
 interface SFIconProps {
   name: SFSymbol;
@@ -11,8 +11,15 @@ interface SFIconProps {
   style?: StyleProp<ViewStyle>;
 }
 
-export function SFIcon({ name, fallback, size = 24, color, weight, style }: SFIconProps) {
-  if (Platform.OS === 'ios') {
+export function SFIcon({
+  name,
+  fallback,
+  size = 24,
+  color,
+  weight,
+  style,
+}: SFIconProps) {
+  if (Platform.OS === "ios") {
     return (
       <SymbolView
         name={name}
@@ -23,5 +30,7 @@ export function SFIcon({ name, fallback, size = 24, color, weight, style }: SFIc
       />
     );
   }
-  return <Ionicons name={fallback} size={size} color={color} style={style as any} />;
+  return (
+    <Ionicons name={fallback} size={size} color={color} style={style as any} />
+  );
 }

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -45,26 +45,40 @@ export function ProfileScreen() {
     () => getPostsByUserId(currentUser.id),
     [currentUser.id]
   );
-  const { data: posts, refetch: refetchPosts } = useQuery(fetchPosts, ['posts', 'user', currentUser.id]);
-  const { data: allPlaces, refetch: refetchPlaces } = useQuery(getPlaces, 'places');
+  const { data: posts, refetch: refetchPosts } = useQuery(fetchPosts, [
+    "posts",
+    "user",
+    currentUser.id,
+  ]);
+  const { data: allPlaces, refetch: refetchPlaces } = useQuery(
+    getPlaces,
+    "places"
+  );
   const fetchCounts = useCallback(
     () => getFollowCounts(currentUser.id),
     [currentUser.id]
   );
-  const { data: counts, refetch: refetchCounts } = useQuery(fetchCounts, ['follow-counts', currentUser.id]);
+  const { data: counts, refetch: refetchCounts } = useQuery(fetchCounts, [
+    "follow-counts",
+    currentUser.id,
+  ]);
   const fetchAchievementCount = useCallback(
     () => getUnlockedAchievementCount(currentUser.id),
     [currentUser.id]
   );
   const { data: achievementCount, refetch: refetchAchievementCount } = useQuery(
     fetchAchievementCount,
-    ['achievement-count', currentUser.id]
+    ["achievement-count", currentUser.id]
   );
   const fetchEvents = useCallback(
     () => getEventsByUserId(currentUser.id),
     [currentUser.id]
   );
-  const { data: events, refetch: refetchEvents } = useQuery(fetchEvents, ['events', 'user', currentUser.id]);
+  const { data: events, refetch: refetchEvents } = useQuery(fetchEvents, [
+    "events",
+    "user",
+    currentUser.id,
+  ]);
 
   // Refetch data when screen comes into focus (e.g., after creating a new post)
   useFocusEffect(

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,8 +1,8 @@
 // Wellington color theme
 export const colors = {
   // Brand
-  primary: "#00A5E0",
-  primaryDark: "#0086B8",
+  primary: "#F5A623",
+  primaryDark: "#D4930D",
 
   // Background
   background: "#FFFFFF",
@@ -34,7 +34,7 @@ export const colors = {
 
   // Interactive
   liked: "#E0245E",
-  saved: "#F5A623",
+  saved: "#E8962E",
 
   // Semantic
   error: "#DC2626",


### PR DESCRIPTION
## Summary
- Update primary brand color from blue (#00A5E0) to warm gold (#F5A623) and adjust related colors
- Add `tintColor` to NativeTabs for consistent active tab highlighting
- Simplify `FloatingCreateButton` by removing the glow animation and increasing the sparkles icon size
- Formatting cleanup in `SFIcon` and `ProfileScreen`
- Document CI/Quality tooling in `claude.md`

## Test plan
- [ ] Verify tab bar icons tint correctly with the new gold color
- [ ] Confirm the floating create button renders without the glow animation
- [ ] Check the sparkles icon is sized/colored correctly on the FAB
- [ ] Verify brand color appears correctly across the app (buttons, links, highlights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)