### PR TITLE
fix: scope post-media upload policy to user paths

### DIFF
--- a/src/screens/CreatePostSheetScreen.tsx
+++ b/src/screens/CreatePostSheetScreen.tsx
@@ -296,7 +296,7 @@ export function CreatePostSheetScreen() {
               const extension = item.type === "video" ? "mp4" : "jpg";
               const mimeType = item.type === "video" ? "video/mp4" : "image/jpeg";
               const fileName = `${profile.id}-${Date.now()}-${index}.${extension}`;
-              const url = await uploadMedia(compressedUri, fileName, mimeType);
+              const url = await uploadMedia(profile.id, compressedUri, fileName, mimeType);
               return {
                 mediaUrl: url,
                 mediaType: item.type,
@@ -345,7 +345,7 @@ export function CreatePostSheetScreen() {
         if (eventImageUri) {
           const compressedUri = await compressMedia(eventImageUri, "photo");
           const fileName = `${profile.id}-event-${Date.now()}.jpg`;
-          imageUrl = await uploadMedia(compressedUri, fileName, "image/jpeg");
+          imageUrl = await uploadMedia(profile.id, compressedUri, fileName, "image/jpeg");
         }
 
         const dateStr = eventDate!.toISOString().split("T")[0];

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -5,6 +5,7 @@ const POST_MEDIA_BUCKET = 'post-media';
 const AVATARS_BUCKET = 'avatars';
 
 export async function uploadMedia(
+  userId: string,
   uri: string,
   fileName: string,
   mimeType: string,
@@ -32,7 +33,7 @@ export async function uploadMedia(
       throw new Error('Media file is empty');
     }
 
-    const filePath = `${Date.now()}-${fileName}`;
+    const filePath = `${userId}/${Date.now()}-${fileName}`;
 
     const { data, error } = await supabase.storage
       .from(POST_MEDIA_BUCKET)

--- a/supabase/migrations/20260221200000_scope_post_media_upload_policy.sql
+++ b/supabase/migrations/20260221200000_scope_post_media_upload_policy.sql
@@ -1,0 +1,8 @@
+drop policy "Authenticated users can upload post media" on storage.objects;
+
+create policy "Authenticated users can upload post media"
+  on storage.objects for insert with check (
+    bucket_id = 'post-media'
+    and auth.role() = 'authenticated'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -286,6 +286,7 @@ create policy "Authenticated users can upload post media"
   on storage.objects for insert with check (
     bucket_id = 'post-media'
     and auth.role() = 'authenticated'
+    and (storage.foldername(name))[1] = auth.uid()::text
   );
 
 create policy "Users can delete own post media"


### PR DESCRIPTION
## Summary
- Adds RLS policy check `(storage.foldername(name))[1] = auth.uid()::text` to the `post-media` bucket insert policy, preventing users from uploading to other users' media folders
- Updates `uploadMedia()` to prefix storage paths with `userId/`, matching the folder structure the RLS policy enforces
- Includes a migration to update the existing policy and keeps `schema.sql` in sync

## Test plan
- [ ] Create a post with photo/video media and verify the file uploads to `{userId}/...` path in Supabase Storage
- [ ] Verify the uploaded media URL resolves correctly and displays in posts
- [ ] Confirm `npx tsc --noEmit` passes with no type errors
- [ ] Run CI checks (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)