### PR TITLE
fix: move Anthropic API key to server-side Edge Function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,18 @@ jobs:
           node-version: 20
           cache: npm
 
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
       - name: Typecheck
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
       - name: Lint
-        run: npx eslint .
+        run: npm run lint
 
       - name: Test
         run: npm test

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,6 @@ import eslintConfigExpo from "eslint-config-expo/flat.js";
 export default [
   ...eslintConfigExpo,
   {
-    ignores: ["node_modules/", ".expo/", "ios/", "android/"],
+    ignores: ["node_modules/", ".expo/", "ios/", "android/", "supabase/functions/"],
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "--legacy-peer-deps": "^0.0.1-security.6",
-        "@anthropic-ai/sdk": "^0.77.0",
         "@expo-google-fonts/dm-sans": "^0.4.2",
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo-google-fonts/pacifico": "^0.4.1",
@@ -92,26 +91,6 @@
       },
       "peerDependenciesMeta": {
         "graphql": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.77.0.tgz",
-      "integrity": "sha512-TivlT6nfidz3sOyMF72T2x5AkmHrpT7JgL2e/0HNdh7b24v7JC8cR+rCY/42jA68xIsjmiGQ5IKMsH9feEKh3A==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
           "optional": true
         }
       }
@@ -13162,19 +13141,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -17455,12 +17421,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,12 @@
     "db:stamp:production": "dotenv -e .env.production -- node supabase/run-sql.mjs supabase/stamp-migrations.sql",
     "db:seed:production": "dotenv -e .env.production -- node supabase/run-sql.mjs supabase/seed-achievements.sql",
     "db:link:production": "supabase link --project-ref cxipwnwxvkguxtbzvnlz",
-    "lint": "eslint .",
-    "typecheck": "tsc --noEmit",
+    "lint": "eslint . && deno lint --config supabase/functions/deno.json supabase/functions/",
+    "typecheck": "tsc --noEmit && deno check --config supabase/functions/deno.json supabase/functions/ai-chat/index.ts",
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "--legacy-peer-deps": "^0.0.1-security.6",
-    "@anthropic-ai/sdk": "^0.77.0",
     "@expo-google-fonts/dm-sans": "^0.4.2",
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo-google-fonts/pacifico": "^0.4.1",

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -1,9 +1,5 @@
-import Anthropic from '@anthropic-ai/sdk';
 import type { Place, Event, Post, User, AIResponse } from '../types';
-
-const client = new Anthropic({
-  apiKey: process.env.EXPO_PUBLIC_ANTHROPIC_API_KEY ?? '',
-});
+import { supabase } from '../lib/supabase';
 
 interface AIContext {
   places: Place[];
@@ -11,180 +7,6 @@ interface AIContext {
   feedPosts: (Post & { userName?: string; placeName?: string })[];
   followingUsers: User[];
   userLocation: { latitude: number; longitude: number } | null;
-}
-
-const WEATHER_CODES: Record<number, string> = {
-  0: 'Clear sky',
-  1: 'Mainly clear',
-  2: 'Partly cloudy',
-  3: 'Overcast',
-  45: 'Foggy',
-  48: 'Foggy',
-  51: 'Light drizzle',
-  53: 'Drizzle',
-  55: 'Heavy drizzle',
-  61: 'Light rain',
-  63: 'Rain',
-  65: 'Heavy rain',
-  71: 'Light snow',
-  73: 'Snow',
-  75: 'Heavy snow',
-  80: 'Light rain showers',
-  81: 'Rain showers',
-  82: 'Heavy rain showers',
-  85: 'Snow showers',
-  86: 'Heavy snow showers',
-  95: 'Thunderstorm',
-  96: 'Thunderstorm with hail',
-  99: 'Thunderstorm with heavy hail',
-};
-
-async function fetchWeather(): Promise<string> {
-  try {
-    const res = await fetch(
-      'https://api.open-meteo.com/v1/forecast?latitude=-41.2924&longitude=174.7787&current=temperature_2m,weather_code,wind_speed_10m,precipitation&timezone=Pacific%2FAuckland',
-    );
-    const data = await res.json();
-    const current = data.current;
-    const condition = WEATHER_CODES[current.weather_code] ?? 'Unknown';
-    return `Current weather in Wellington: ${condition}, ${current.temperature_2m}°C, wind ${current.wind_speed_10m} km/h${current.precipitation > 0 ? `, ${current.precipitation}mm precipitation` : ''}.`;
-  } catch {
-    return '';
-  }
-}
-
-function buildSystemPrompt(ctx: AIContext, weather: string): string {
-  const now = new Date();
-  const dateStr = now.toLocaleDateString('en-NZ', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-  const timeStr = now.toLocaleTimeString('en-NZ', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-
-  const locationStr = ctx.userLocation
-    ? `User is near (${ctx.userLocation.latitude.toFixed(4)}, ${ctx.userLocation.longitude.toFixed(4)}) in Wellington.`
-    : 'User location unknown, assume they are in Wellington.';
-
-  // Compact places: id|name|category
-  const placesStr = ctx.places
-    .slice(0, 30)
-    .map((p) => `${p.id}|${p.name}|${p.category}`)
-    .join('\n');
-
-  // Events within next 14 days
-  const twoWeeks = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000);
-  const upcomingEvents = ctx.events
-    .filter((e) => {
-      const eventDate = new Date(e.date);
-      return eventDate >= now && eventDate <= twoWeeks;
-    })
-    .slice(0, 30);
-
-  const followingSet = new Set(ctx.followingUsers.map((u) => u.id));
-  const followingNameMap = new Map(ctx.followingUsers.map((u) => [u.id, u.displayName ?? u.username]));
-
-  const eventsStr = upcomingEvents
-    .map((e) => {
-      const attendingFollowed = (e.attendeeIds ?? [])
-        .filter((id) => followingSet.has(id))
-        .map((id) => followingNameMap.get(id))
-        .filter(Boolean);
-      const attendeeStr = attendingFollowed.length > 0
-        ? `|attending: ${attendingFollowed.join(', ')}`
-        : '';
-      return `${e.id}|${e.title}|${e.date}|${e.startTime}|${e.category}${e.price ? `|$${e.price}` : '|free'}${attendeeStr}`;
-    })
-    .join('\n');
-
-  // Followed users: id|name
-  const followingStr = ctx.followingUsers
-    .slice(0, 30)
-    .map((u) => `${u.id}|${u.displayName ?? u.username}`)
-    .join('\n');
-
-  // Recent feed posts with context
-  const postsStr = ctx.feedPosts
-    .slice(0, 50)
-    .map((p) => `${p.userName ?? 'someone'}|${p.placeName ?? 'unknown place'}|${p.content.slice(0, 100)}`)
-    .join('\n');
-
-  return `You are Welly, a friendly AI assistant for the Welly app — a map-based social platform for discovering things to do in Wellington, New Zealand.
-
-Current date/time: ${dateStr}, ${timeStr}
-${locationStr}
-${weather}
-
-PLACES (id|name|category):
-${placesStr || 'No places loaded yet.'}
-
-UPCOMING EVENTS (id|title|date|startTime|category|price|followed attending):
-${eventsStr || 'No upcoming events.'}
-
-FOLLOWED USERS (id|name):
-${followingStr || 'Not following anyone yet.'}
-
-RECENT POSTS FROM FOLLOWED USERS (user|place|content):
-${postsStr || 'No recent posts.'}
-
-INSTRUCTIONS:
-- Use emojis naturally throughout your responses to keep things fun and friendly (e.g. ☕ for cafes, 🍕 for restaurants, 🎶 for music events, 🌿 for parks, etc.)
-- Give friendly, concise recommendations based on the data above
-- When mentioning places, events, or users in your message text, use inline markdown links with these URI schemes:
-  - Places: [Place Name](place:placeId)
-  - Events: [Event Title](event:eventId)
-  - Users: [Display Name](user:userId)
-  For example: "Check out [Cafe Polo](place:abc-123) — [Sarah](user:def-456) posted about it recently!"
-- Consider the time of day, day of week, and current weather when suggesting activities (e.g. indoor spots on rainy days, outdoor activities when it's nice)
-- Prioritize places and events that the user's followed people have posted about or are attending
-- When followed users are attending an event, mention them by name (e.g. "Sarah and Mike are going to this one!")
-- Keep your message to 2-3 short paragraphs max
-- ONLY return valid JSON and nothing else. No text before or after the JSON. Use this exact format:
-{
-  "message": "Your friendly response text here",
-  "places": [{"placeId": "uuid", "placeName": "Name", "category": "cafe", "reason": "Short reason"}],
-  "events": [{"eventId": "uuid", "eventTitle": "Title", "date": "2026-02-20", "startTime": "18:00", "reason": "Short reason"}]
-}
-- Only include places/events that exist in the data above
-- Include 1-4 places and 0-3 events as relevant to the question
-- If the question is unrelated to Wellington activities, respond helpfully but keep places/events arrays empty`;
-}
-
-function parseAIResponse(text: string): AIResponse {
-  // Try direct JSON parse
-  try {
-    const parsed = JSON.parse(text);
-    if (parsed.message) return parsed;
-  } catch {}
-
-  // Try extracting from markdown code fences
-  const codeBlockMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
-  if (codeBlockMatch) {
-    try {
-      const parsed = JSON.parse(codeBlockMatch[1]);
-      if (parsed.message) return parsed;
-    } catch {}
-  }
-
-  // Try extracting a JSON object from anywhere in the text
-  const jsonMatch = text.match(/\{[\s\S]*"message"\s*:\s*"[\s\S]*\}/);
-  if (jsonMatch) {
-    try {
-      const parsed = JSON.parse(jsonMatch[0]);
-      if (parsed.message) return parsed;
-    } catch {}
-  }
-
-  // Fallback: use raw text as message
-  return {
-    message: text,
-    places: [],
-    events: [],
-  };
 }
 
 export interface ConversationMessage {
@@ -196,20 +18,18 @@ export async function askAI(
   messages: ConversationMessage[],
   ctx: AIContext,
 ): Promise<AIResponse> {
-  const weather = await fetchWeather();
-  const systemPrompt = buildSystemPrompt(ctx, weather);
-
-  const response = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
-    max_tokens: 1024,
-    system: systemPrompt,
-    messages: messages.map((m) => ({ role: m.role, content: m.content })),
+  const { data, error } = await supabase.functions.invoke('ai-chat', {
+    body: { messages, context: ctx },
   });
 
-  const textBlock = response.content.find((block) => block.type === 'text');
-  if (!textBlock || textBlock.type !== 'text') {
-    throw new Error('No text response from AI');
+  if (error) {
+    const errorBody = await error.context?.json?.().catch(() => null);
+    throw new Error(errorBody?.error ?? error.message ?? 'AI request failed');
   }
 
-  return parseAIResponse(textBlock.text);
+  if (data?.error) {
+    throw new Error(data.error);
+  }
+
+  return data as AIResponse;
 }

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -1,0 +1,317 @@
+import { createClient } from "@supabase/supabase-js";
+import Anthropic from "@anthropic-ai/sdk";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+interface Place {
+  id: string;
+  name: string;
+  category: string;
+}
+
+interface Event {
+  id: string;
+  title: string;
+  date: string;
+  startTime: string;
+  category: string;
+  price?: number;
+  attendeeIds?: string[];
+}
+
+interface FeedPost {
+  content: string;
+  userName?: string;
+  placeName?: string;
+}
+
+interface FollowingUser {
+  id: string;
+  username: string;
+  displayName?: string;
+}
+
+interface AIContext {
+  places: Place[];
+  events: Event[];
+  feedPosts: FeedPost[];
+  followingUsers: FollowingUser[];
+  userLocation: { latitude: number; longitude: number } | null;
+}
+
+interface ConversationMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface AIResponse {
+  message: string;
+  places: { placeId: string; placeName: string; category: string; reason: string }[];
+  events: { eventId: string; eventTitle: string; date: string; startTime?: string; reason: string }[];
+}
+
+const WEATHER_CODES: Record<number, string> = {
+  0: "Clear sky",
+  1: "Mainly clear",
+  2: "Partly cloudy",
+  3: "Overcast",
+  45: "Foggy",
+  48: "Foggy",
+  51: "Light drizzle",
+  53: "Drizzle",
+  55: "Heavy drizzle",
+  61: "Light rain",
+  63: "Rain",
+  65: "Heavy rain",
+  71: "Light snow",
+  73: "Snow",
+  75: "Heavy snow",
+  80: "Light rain showers",
+  81: "Rain showers",
+  82: "Heavy rain showers",
+  85: "Snow showers",
+  86: "Heavy snow showers",
+  95: "Thunderstorm",
+  96: "Thunderstorm with hail",
+  99: "Thunderstorm with heavy hail",
+};
+
+async function fetchWeather(): Promise<string> {
+  try {
+    const res = await fetch(
+      "https://api.open-meteo.com/v1/forecast?latitude=-41.2924&longitude=174.7787&current=temperature_2m,weather_code,wind_speed_10m,precipitation&timezone=Pacific%2FAuckland"
+    );
+    const data = await res.json();
+    const current = data.current;
+    const condition = WEATHER_CODES[current.weather_code] ?? "Unknown";
+    return `Current weather in Wellington: ${condition}, ${current.temperature_2m}°C, wind ${current.wind_speed_10m} km/h${current.precipitation > 0 ? `, ${current.precipitation}mm precipitation` : ""}.`;
+  } catch {
+    return "";
+  }
+}
+
+function buildSystemPrompt(ctx: AIContext, weather: string): string {
+  const now = new Date();
+  const dateStr = now.toLocaleDateString("en-NZ", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  const timeStr = now.toLocaleTimeString("en-NZ", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const locationStr = ctx.userLocation
+    ? `User is near (${ctx.userLocation.latitude.toFixed(4)}, ${ctx.userLocation.longitude.toFixed(4)}) in Wellington.`
+    : "User location unknown, assume they are in Wellington.";
+
+  const placesStr = ctx.places
+    .slice(0, 30)
+    .map((p) => `${p.id}|${p.name}|${p.category}`)
+    .join("\n");
+
+  const twoWeeks = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000);
+  const upcomingEvents = ctx.events
+    .filter((e) => {
+      const eventDate = new Date(e.date);
+      return eventDate >= now && eventDate <= twoWeeks;
+    })
+    .slice(0, 30);
+
+  const followingSet = new Set(ctx.followingUsers.map((u) => u.id));
+  const followingNameMap = new Map(
+    ctx.followingUsers.map((u) => [u.id, u.displayName ?? u.username])
+  );
+
+  const eventsStr = upcomingEvents
+    .map((e) => {
+      const attendingFollowed = (e.attendeeIds ?? [])
+        .filter((id) => followingSet.has(id))
+        .map((id) => followingNameMap.get(id))
+        .filter(Boolean);
+      const attendeeStr =
+        attendingFollowed.length > 0
+          ? `|attending: ${attendingFollowed.join(", ")}`
+          : "";
+      return `${e.id}|${e.title}|${e.date}|${e.startTime}|${e.category}${e.price ? `|$${e.price}` : "|free"}${attendeeStr}`;
+    })
+    .join("\n");
+
+  const followingStr = ctx.followingUsers
+    .slice(0, 30)
+    .map((u) => `${u.id}|${u.displayName ?? u.username}`)
+    .join("\n");
+
+  const postsStr = ctx.feedPosts
+    .slice(0, 50)
+    .map(
+      (p) =>
+        `${p.userName ?? "someone"}|${p.placeName ?? "unknown place"}|${p.content.slice(0, 100)}`
+    )
+    .join("\n");
+
+  return `You are Welly, a friendly AI assistant for the Welly app — a map-based social platform for discovering things to do in Wellington, New Zealand.
+
+Current date/time: ${dateStr}, ${timeStr}
+${locationStr}
+${weather}
+
+PLACES (id|name|category):
+${placesStr || "No places loaded yet."}
+
+UPCOMING EVENTS (id|title|date|startTime|category|price|followed attending):
+${eventsStr || "No upcoming events."}
+
+FOLLOWED USERS (id|name):
+${followingStr || "Not following anyone yet."}
+
+RECENT POSTS FROM FOLLOWED USERS (user|place|content):
+${postsStr || "No recent posts."}
+
+INSTRUCTIONS:
+- Use emojis naturally throughout your responses to keep things fun and friendly (e.g. ☕ for cafes, 🍕 for restaurants, 🎶 for music events, 🌿 for parks, etc.)
+- Give friendly, concise recommendations based on the data above
+- When mentioning places, events, or users in your message text, use inline markdown links with these URI schemes:
+  - Places: [Place Name](place:placeId)
+  - Events: [Event Title](event:eventId)
+  - Users: [Display Name](user:userId)
+  For example: "Check out [Cafe Polo](place:abc-123) — [Sarah](user:def-456) posted about it recently!"
+- Consider the time of day, day of week, and current weather when suggesting activities (e.g. indoor spots on rainy days, outdoor activities when it's nice)
+- Prioritize places and events that the user's followed people have posted about or are attending
+- When followed users are attending an event, mention them by name (e.g. "Sarah and Mike are going to this one!")
+- Keep your message to 2-3 short paragraphs max
+- ONLY return valid JSON and nothing else. No text before or after the JSON. Use this exact format:
+{
+  "message": "Your friendly response text here",
+  "places": [{"placeId": "uuid", "placeName": "Name", "category": "cafe", "reason": "Short reason"}],
+  "events": [{"eventId": "uuid", "eventTitle": "Title", "date": "2026-02-20", "startTime": "18:00", "reason": "Short reason"}]
+}
+- Only include places/events that exist in the data above
+- Include 1-4 places and 0-3 events as relevant to the question
+- If the question is unrelated to Wellington activities, respond helpfully but keep places/events arrays empty`;
+}
+
+function parseAIResponse(text: string): AIResponse {
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed.message) return parsed;
+  } catch { /* continue */ }
+
+  const codeBlockMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  if (codeBlockMatch) {
+    try {
+      const parsed = JSON.parse(codeBlockMatch[1]);
+      if (parsed.message) return parsed;
+    } catch { /* continue */ }
+  }
+
+  const jsonMatch = text.match(/\{[\s\S]*"message"\s*:\s*"[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      const parsed = JSON.parse(jsonMatch[0]);
+      if (parsed.message) return parsed;
+    } catch { /* continue */ }
+  }
+
+  return {
+    message: text,
+    places: [],
+    events: [],
+  };
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    // Verify the user is authenticated
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: "Missing authorization header" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      { global: { headers: { Authorization: authHeader } } }
+    );
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      console.error("[ai-chat] Auth failed:", authError?.message ?? "no user");
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { messages, context } = (await req.json()) as {
+      messages: ConversationMessage[];
+      context: AIContext;
+    };
+
+    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+      return new Response(JSON.stringify({ error: "Messages are required" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+    if (!apiKey) {
+      console.error("[ai-chat] ANTHROPIC_API_KEY not set in secrets");
+      return new Response(JSON.stringify({ error: "AI service not configured" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const client = new Anthropic({ apiKey });
+
+    const weather = await fetchWeather();
+    const systemPrompt = buildSystemPrompt(context, weather);
+
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 1024,
+      system: systemPrompt,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+    });
+
+    const textBlock = response.content.find(
+      (block: { type: string }) => block.type === "text"
+    );
+    if (!textBlock || textBlock.type !== "text") {
+      return new Response(JSON.stringify({ error: "No text response from AI" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const aiResponse = parseAIResponse(
+      (textBlock as { type: "text"; text: string }).text
+    );
+
+    return new Response(JSON.stringify(aiResponse), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Internal server error";
+    console.error("[ai-chat] Error:", message);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,12 @@
+{
+  "lock": false,
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2",
+    "@anthropic-ai/sdk": "https://esm.sh/@anthropic-ai/sdk@0.39.0"
+  },
+  "lint": {
+    "rules": {
+      "exclude": ["no-explicit-any"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "strict": true,
     "baseUrl": "."
-  }
+  },
+  "exclude": ["supabase/functions"]
 }


### PR DESCRIPTION
## Summary

- **Security fix**: The Anthropic API key was exposed in the client JS bundle via the `EXPO_PUBLIC_` prefix. Anyone extracting the app binary could recover the key and make unlimited API calls.
- All AI logic (system prompt, weather fetch, response parsing) moved to a new `supabase/functions/ai-chat` Edge Function that validates auth and calls Anthropic server-side
- `src/services/ai.ts` rewritten as a thin proxy using `supabase.functions.invoke()`
- `@anthropic-ai/sdk` removed from client dependencies
- Deno type checking (`deno check`) and linting (`deno lint`) added to CI via `denoland/setup-deno@v2`

## Deployment

After merging, deploy the Edge Function to both projects:

```bash
supabase functions deploy ai-chat --no-verify-jwt --project-ref <project-ref>
supabase secrets set ANTHROPIC_API_KEY=<new-key> --project-ref <project-ref>
```

**Important**: The old API key was committed to git history and must be rotated via the Anthropic dashboard.

## Test plan

- [ ] Verify `npm run typecheck` passes (tsc + deno check)
- [ ] Verify `npm run lint` passes (eslint + deno lint)
- [ ] Verify `@anthropic-ai/sdk` is not in `package.json`
- [ ] Deploy Edge Function and verify AI chat works end-to-end
- [ ] Verify `EXPO_PUBLIC_ANTHROPIC_API_KEY` is not in any env files

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)