### PR TITLE
fix: move Instagram App Secret to server-side Edge Function

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "db:seed:production": "dotenv -e .env.production -- node supabase/run-sql.mjs supabase/seed-achievements.sql",
     "db:link:production": "supabase link --project-ref cxipwnwxvkguxtbzvnlz",
     "lint": "eslint . && deno lint --config supabase/functions/deno.json supabase/functions/",
-    "typecheck": "tsc --noEmit && deno check --config supabase/functions/deno.json supabase/functions/ai-chat/index.ts",
+    "typecheck": "tsc --noEmit && deno check --config supabase/functions/deno.json supabase/functions/*/index.ts",
     "test": "jest --passWithNoTests"
   },
   "dependencies": {

--- a/src/services/instagram.ts
+++ b/src/services/instagram.ts
@@ -4,7 +4,6 @@ import { supabase } from '../lib/supabase';
 import type { InstagramConnection } from '../types/Instagram';
 
 const INSTAGRAM_APP_ID = process.env.EXPO_PUBLIC_INSTAGRAM_APP_ID!;
-const INSTAGRAM_APP_SECRET = process.env.EXPO_PUBLIC_INSTAGRAM_APP_SECRET!;
 const REDIRECT_URI = 'https://wellyapp.nz/auth/instagram/callback';
 const APP_REDIRECT_URI = 'wellington://instagram-callback';
 const SECURE_STORE_KEY = 'instagram_access_token';
@@ -36,87 +35,34 @@ export async function connectInstagram(): Promise<InstagramConnection> {
     throw new Error('No authorization code returned from Instagram');
   }
 
-  // Exchange code for short-lived token
-  const tokenForm = new URLSearchParams();
-  tokenForm.append('client_id', INSTAGRAM_APP_ID);
-  tokenForm.append('client_secret', INSTAGRAM_APP_SECRET);
-  tokenForm.append('grant_type', 'authorization_code');
-  tokenForm.append('redirect_uri', REDIRECT_URI);
-  tokenForm.append('code', code);
-
-  console.log('[Instagram] Exchanging code for token...');
-  const tokenRes = await fetch('https://api.instagram.com/oauth/access_token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: tokenForm.toString(),
+  // Exchange code for tokens via server-side Edge Function
+  console.log('[Instagram] Exchanging code for token via Edge Function...');
+  const { data: fnData, error: fnError } = await supabase.functions.invoke('instagram-token', {
+    body: { code },
   });
 
-  if (!tokenRes.ok) {
-    const tokenErr = await tokenRes.text();
-    console.error('[Instagram] Token exchange failed:', tokenRes.status, tokenErr);
+  if (fnError) {
+    console.error('[Instagram] Edge Function error:', fnError.message);
     throw new Error('Failed to exchange Instagram authorization code');
   }
 
-  const tokenData = await tokenRes.json();
-  const shortLivedToken: string = tokenData.access_token;
-  const igUserId: string = String(tokenData.user_id);
-
-  // Exchange short-lived token for long-lived token (60 days)
-  const longLivedRes = await fetch(
-    `https://graph.instagram.com/access_token` +
-      `?grant_type=ig_exchange_token` +
-      `&client_secret=${INSTAGRAM_APP_SECRET}` +
-      `&access_token=${shortLivedToken}`
-  );
-
-  if (!longLivedRes.ok) {
-    throw new Error('Failed to get long-lived Instagram token');
+  if (fnData.error) {
+    console.error('[Instagram] Server error:', fnData.error);
+    throw new Error(fnData.error);
   }
-
-  const longLivedData = await longLivedRes.json();
-  const accessToken: string = longLivedData.access_token;
-  const expiresIn: number = longLivedData.expires_in; // seconds
-
-  // Fetch Instagram username
-  const profileRes = await fetch(
-    `https://graph.instagram.com/me?fields=username&access_token=${accessToken}`
-  );
-
-  if (!profileRes.ok) {
-    throw new Error('Failed to fetch Instagram profile');
-  }
-
-  const profileData = await profileRes.json();
-  const igUsername: string = profileData.username;
-
-  const tokenExpiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
-
-  // Get current user
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error('Not authenticated');
-
-  // Upsert connection in Supabase
-  const { data, error } = await supabase
-    .from('instagram_connections')
-    .upsert(
-      {
-        user_id: user.id,
-        instagram_user_id: igUserId,
-        instagram_username: igUsername,
-        access_token: accessToken,
-        token_expires_at: tokenExpiresAt,
-      },
-      { onConflict: 'user_id' }
-    )
-    .select()
-    .single();
-
-  if (error) throw error;
 
   // Cache token in secure store for fast access
-  await SecureStore.setItemAsync(SECURE_STORE_KEY, accessToken);
+  await SecureStore.setItemAsync(SECURE_STORE_KEY, fnData.accessToken);
 
-  return mapConnection(data);
+  return {
+    id: '',
+    userId: '',
+    instagramUserId: fnData.instagramUserId,
+    instagramUsername: fnData.instagramUsername,
+    accessToken: fnData.accessToken,
+    tokenExpiresAt: fnData.tokenExpiresAt,
+    connectedAt: fnData.connectedAt,
+  };
 }
 
 export async function disconnectInstagram(): Promise<void> {

--- a/supabase/functions/instagram-token/index.ts
+++ b/supabase/functions/instagram-token/index.ts
@@ -1,0 +1,168 @@
+import { createClient } from "@supabase/supabase-js";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+const INSTAGRAM_APP_ID = Deno.env.get("INSTAGRAM_APP_ID") ?? "";
+const INSTAGRAM_APP_SECRET = Deno.env.get("INSTAGRAM_APP_SECRET") ?? "";
+const REDIRECT_URI = "https://wellyapp.nz/auth/instagram/callback";
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    // Verify the user is authenticated
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: "Missing authorization header" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      { global: { headers: { Authorization: authHeader } } }
+    );
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      console.error("[instagram-token] Auth failed:", authError?.message ?? "no user");
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (!INSTAGRAM_APP_SECRET) {
+      console.error("[instagram-token] INSTAGRAM_APP_SECRET not set in secrets");
+      return new Response(JSON.stringify({ error: "Instagram integration not configured" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { code } = (await req.json()) as { code: string };
+    if (!code) {
+      return new Response(JSON.stringify({ error: "Authorization code is required" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // Exchange code for short-lived token
+    const tokenForm = new URLSearchParams();
+    tokenForm.append("client_id", INSTAGRAM_APP_ID);
+    tokenForm.append("client_secret", INSTAGRAM_APP_SECRET);
+    tokenForm.append("grant_type", "authorization_code");
+    tokenForm.append("redirect_uri", REDIRECT_URI);
+    tokenForm.append("code", code);
+
+    const tokenRes = await fetch("https://api.instagram.com/oauth/access_token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: tokenForm.toString(),
+    });
+
+    if (!tokenRes.ok) {
+      const tokenErr = await tokenRes.text();
+      console.error("[instagram-token] Token exchange failed:", tokenRes.status, tokenErr);
+      return new Response(JSON.stringify({ error: "Failed to exchange Instagram authorization code" }), {
+        status: 502,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const tokenData = await tokenRes.json();
+    const shortLivedToken: string = tokenData.access_token;
+    const igUserId: string = String(tokenData.user_id);
+
+    // Exchange short-lived token for long-lived token (60 days)
+    const longLivedRes = await fetch(
+      `https://graph.instagram.com/access_token` +
+        `?grant_type=ig_exchange_token` +
+        `&client_secret=${INSTAGRAM_APP_SECRET}` +
+        `&access_token=${shortLivedToken}`
+    );
+
+    if (!longLivedRes.ok) {
+      const llErr = await longLivedRes.text();
+      console.error("[instagram-token] Long-lived token exchange failed:", longLivedRes.status, llErr);
+      return new Response(JSON.stringify({ error: "Failed to get long-lived Instagram token" }), {
+        status: 502,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const longLivedData = await longLivedRes.json();
+    const accessToken: string = longLivedData.access_token;
+    const expiresIn: number = longLivedData.expires_in;
+
+    // Fetch Instagram username
+    const profileRes = await fetch(
+      `https://graph.instagram.com/me?fields=username&access_token=${accessToken}`
+    );
+
+    if (!profileRes.ok) {
+      return new Response(JSON.stringify({ error: "Failed to fetch Instagram profile" }), {
+        status: 502,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const profileData = await profileRes.json();
+    const igUsername: string = profileData.username;
+
+    const tokenExpiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+
+    // Upsert connection in database
+    const { data, error } = await supabase
+      .from("instagram_connections")
+      .upsert(
+        {
+          user_id: user.id,
+          instagram_user_id: igUserId,
+          instagram_username: igUsername,
+          access_token: accessToken,
+          token_expires_at: tokenExpiresAt,
+        },
+        { onConflict: "user_id" }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      console.error("[instagram-token] DB upsert failed:", error.message);
+      return new Response(JSON.stringify({ error: "Failed to save Instagram connection" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        instagramUserId: data.instagram_user_id,
+        instagramUsername: data.instagram_username,
+        accessToken: data.access_token,
+        tokenExpiresAt: data.token_expires_at,
+        connectedAt: data.connected_at,
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Internal server error";
+    console.error("[instagram-token] Error:", message);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Created `instagram-token` Supabase Edge Function that handles the full Instagram OAuth token exchange server-side (short-lived → long-lived token, username fetch, DB upsert)
- Updated `connectInstagram()` in the client to call the Edge Function instead of making token exchange requests directly, removing `EXPO_PUBLIC_INSTAGRAM_APP_SECRET` from the client bundle
- Updated typecheck script to use wildcard glob (`supabase/functions/*/index.ts`) so new Edge Functions are automatically included

Closes #14

## Deployment
```bash
supabase secrets set INSTAGRAM_APP_ID=<app-id> INSTAGRAM_APP_SECRET=<rotated-secret> --project-ref <ref>
supabase functions deploy instagram-token --no-verify-jwt --project-ref <ref>
```

## Test plan
- [ ] Verify `EXPO_PUBLIC_INSTAGRAM_APP_SECRET` is no longer in the client bundle
- [ ] Test Instagram OAuth connect flow end-to-end
- [ ] Verify `npm run typecheck` and `npm run lint` pass
- [ ] Deploy Edge Function and set secrets in Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)