### PR TITLE
fix: add error boundaries, secure auth nonce, and avatars RLS

### DIFF
--- a/app/(tabs)/events/_layout.tsx
+++ b/app/(tabs)/events/_layout.tsx
@@ -1,5 +1,10 @@
 import { Stack } from "expo-router";
 import { EventFilterProvider } from "../../../src/context/EventFilterContext";
+import { ErrorScreen } from "../../../src/components/ErrorScreen";
+
+export function ErrorBoundary({ error, retry }: { error: Error; retry: () => void }) {
+  return <ErrorScreen error={error} retry={retry} />;
+}
 
 export default function EventsLayout() {
   return (

--- a/app/(tabs)/feed/_layout.tsx
+++ b/app/(tabs)/feed/_layout.tsx
@@ -1,7 +1,12 @@
 import { Stack, useRouter } from "expo-router";
 import { SFIcon } from "../../../src/components/SFIcon";
 import { HapticPressable } from "../../../src/components/HapticPressable";
+import { ErrorScreen } from "../../../src/components/ErrorScreen";
 import { colors } from "../../../src/theme/colors";
+
+export function ErrorBoundary({ error, retry }: { error: Error; retry: () => void }) {
+  return <ErrorScreen error={error} retry={retry} />;
+}
 
 function DiscoverButton() {
   const router = useRouter();

--- a/app/(tabs)/map/_layout.tsx
+++ b/app/(tabs)/map/_layout.tsx
@@ -1,4 +1,9 @@
 import { Stack } from "expo-router";
+import { ErrorScreen } from "../../../src/components/ErrorScreen";
+
+export function ErrorBoundary({ error, retry }: { error: Error; retry: () => void }) {
+  return <ErrorScreen error={error} retry={retry} />;
+}
 
 export default function MapLayout() {
   return (

--- a/app/(tabs)/profile/_layout.tsx
+++ b/app/(tabs)/profile/_layout.tsx
@@ -3,9 +3,14 @@ import { Stack, useRouter } from "expo-router";
 import { SFIcon } from "../../../src/components/SFIcon";
 import { signOut } from "../../../src/services/auth";
 import { HapticPressable } from "../../../src/components/HapticPressable";
+import { ErrorScreen } from "../../../src/components/ErrorScreen";
 import { useNotifications } from "../../../src/context/NotificationContext";
 import { useSave } from "../../../src/context/SaveContext";
 import { colors } from "../../../src/theme/colors";
+
+export function ErrorBoundary({ error, retry }: { error: Error; retry: () => void }) {
+  return <ErrorScreen error={error} retry={retry} />;
+}
 
 function NotificationBell() {
   const router = useRouter();

--- a/app/(tabs)/search/_layout.tsx
+++ b/app/(tabs)/search/_layout.tsx
@@ -1,4 +1,9 @@
 import { Stack } from "expo-router";
+import { ErrorScreen } from "../../../src/components/ErrorScreen";
+
+export function ErrorBoundary({ error, retry }: { error: Error; retry: () => void }) {
+  return <ErrorScreen error={error} retry={retry} />;
+}
 
 export default function SearchLayout() {
   return (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useShareIntent } from "expo-share-intent";
 import * as SplashScreen from "expo-splash-screen";
+import { ErrorScreen } from "../src/components/ErrorScreen";
 import {
   useFonts,
   PlusJakartaSans_500Medium,
@@ -24,6 +25,10 @@ import { ExplorationProvider } from "../src/context/ExplorationContext";
 import { LocationProvider } from "../src/context/LocationContext";
 import { ZoomOverlayProvider } from "../src/context/ZoomOverlayContext";
 import { StatusBar } from "expo-status-bar";
+
+export function ErrorBoundary({ error, retry }: { error: Error; retry: () => void }) {
+  return <ErrorScreen error={error} retry={retry} />;
+}
 
 SplashScreen.preventAutoHideAsync();
 

--- a/src/components/ErrorScreen.tsx
+++ b/src/components/ErrorScreen.tsx
@@ -1,0 +1,59 @@
+import { View, Text, StyleSheet } from "react-native";
+import { colors } from "../theme/colors";
+import { HapticPressable } from "./HapticPressable";
+
+interface ErrorScreenProps {
+  error: Error;
+  retry: () => void;
+}
+
+export function ErrorScreen({ error, retry }: ErrorScreenProps) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.emoji}>:(</Text>
+      <Text style={styles.title}>Something went wrong</Text>
+      <Text style={styles.message}>{error.message}</Text>
+      <HapticPressable style={styles.button} onPress={retry}>
+        <Text style={styles.buttonText}>Try Again</Text>
+      </HapticPressable>
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 32,
+  },
+  emoji: {
+    fontSize: 48,
+    marginBottom: 16,
+    color: colors.textMuted,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: "PlusJakartaSans_700Bold",
+    color: colors.text,
+    marginBottom: 8,
+  },
+  message: {
+    fontSize: 14,
+    fontFamily: "PlusJakartaSans_500Medium",
+    color: colors.textSecondary,
+    textAlign: "center",
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontFamily: "PlusJakartaSans_600SemiBold",
+    color: "#FFFFFF",
+  },
+});

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -58,8 +58,9 @@ export async function signInWithApple() {
     throw new Error('Apple Sign In is only available on iOS');
   }
 
-  // Generate a random nonce for security
-  const nonce = Math.random().toString(36).substring(2, 10);
+  // Generate a cryptographically secure nonce
+  const nonceBytes = await Crypto.getRandomBytesAsync(32);
+  const nonce = Array.from(nonceBytes).map(b => b.toString(16).padStart(2, '0')).join('');
 
   // Hash the nonce using SHA-256
   const hashedNonce = await Crypto.digestStringAsync(

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -82,8 +82,8 @@ export async function uploadAvatar(
       throw new Error('Image file is empty');
     }
 
-    // Use userId to make avatar path predictable (allows overwriting old avatar)
-    const filePath = `${userId}-${Date.now()}.jpg`;
+    // Use userId subfolder so RLS can enforce ownership via foldername
+    const filePath = `${userId}/${Date.now()}.jpg`;
     console.log('Uploading to path:', filePath);
 
     const { data, error } = await supabase.storage

--- a/supabase/migrations/20260222000000_add_avatars_bucket_rls.sql
+++ b/supabase/migrations/20260222000000_add_avatars_bucket_rls.sql
@@ -1,0 +1,33 @@
+-- Create avatars storage bucket with RLS policies
+-- Fixes: Any authenticated user could overwrite another user's avatar
+
+insert into storage.buckets (id, name, public) values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+-- Drop existing policies if any (idempotent)
+drop policy if exists "Anyone can view avatars" on storage.objects;
+drop policy if exists "Users can upload own avatar" on storage.objects;
+drop policy if exists "Users can update own avatar" on storage.objects;
+drop policy if exists "Users can delete own avatar" on storage.objects;
+
+create policy "Anyone can view avatars"
+  on storage.objects for select using (bucket_id = 'avatars');
+
+create policy "Users can upload own avatar"
+  on storage.objects for insert with check (
+    bucket_id = 'avatars'
+    and auth.role() = 'authenticated'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "Users can update own avatar"
+  on storage.objects for update using (
+    bucket_id = 'avatars'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+create policy "Users can delete own avatar"
+  on storage.objects for delete using (
+    bucket_id = 'avatars'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -390,6 +390,37 @@ create policy "Users can delete own post media"
     and auth.uid()::text = (storage.foldername(name))[1]
   );
 
+-- Storage bucket for avatars
+insert into storage.buckets (id, name, public) values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+drop policy if exists "Anyone can view avatars" on storage.objects;
+drop policy if exists "Users can upload own avatar" on storage.objects;
+drop policy if exists "Users can update own avatar" on storage.objects;
+drop policy if exists "Users can delete own avatar" on storage.objects;
+
+create policy "Anyone can view avatars"
+  on storage.objects for select using (bucket_id = 'avatars');
+
+create policy "Users can upload own avatar"
+  on storage.objects for insert with check (
+    bucket_id = 'avatars'
+    and auth.role() = 'authenticated'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "Users can update own avatar"
+  on storage.objects for update using (
+    bucket_id = 'avatars'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+create policy "Users can delete own avatar"
+  on storage.objects for delete using (
+    bucket_id = 'avatars'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );
+
 -- Trails (linked to shadow place records for post/event support)
 create table trails (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary

- **Error boundaries** (#15): Added React error boundaries at the root layout and each tab layout so a rendering crash in one tab doesn't take down the whole app. Users see a styled error screen with a "Try Again" button instead of a blank white screen.
- **Apple Sign-In nonce** (#17): Replaced `Math.random()` nonce (8 chars, ~41 bits) with `expo-crypto` CSPRNG (64 hex chars, 256 bits) to prevent replay attacks.
- **Avatars bucket RLS** (#18): Added storage bucket creation and RLS policies for `avatars` so users can only upload/update/delete their own avatar. Moved avatar path from flat `userId-timestamp.jpg` to `userId/timestamp.jpg` for consistent folder-based RLS enforcement.

Closes #15, closes #17, closes #18

## Test plan

- [ ] Verify app loads normally with no regressions
- [ ] Trigger a rendering error in one tab and confirm other tabs still work, error screen shows with retry
- [ ] Test Apple Sign-In flow still works with the new CSPRNG nonce
- [ ] Test avatar upload — confirm it saves to `userId/` subfolder and RLS blocks cross-user writes
- [ ] Run migration on a database that already has avatars policies (idempotent via `DROP IF EXISTS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)