### PR TITLE
Add Maestro e2e tests for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ supabase/.temp/
 # typescript
 *.tsbuildinfo
 
+# Maestro
+.maestro/screenshots/
+
 # generated native folders
 /ios
 /android

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,0 +1,1 @@
+appId: com.malinmw.wellingtonapp

--- a/.maestro/events.yaml
+++ b/.maestro/events.yaml
@@ -1,0 +1,21 @@
+appId: com.malinmw.wellingtonapp
+name: "Events - Browse events"
+tags:
+  - events
+
+---
+
+# Log in first
+- runFlow: flows/login.yaml
+
+# Navigate to Events tab
+- tapOn: "Events"
+
+# Wait for events content to load
+- extendedWaitUntil:
+    visible: "Today|Tonight|Tomorrow|This Weekend|This Month|Coming Up|No events match"
+    timeout: 10000
+
+# Scroll through events
+- scroll
+- scroll

--- a/.maestro/feed.yaml
+++ b/.maestro/feed.yaml
@@ -1,0 +1,22 @@
+appId: com.malinmw.wellingtonapp
+name: "Feed - Browse feed posts"
+tags:
+  - feed
+
+---
+
+# Log in first
+- runFlow: flows/login.yaml
+
+# Navigate to Feed tab
+- tapOn: "Feed"
+
+# Wait for feed content to appear
+- extendedWaitUntil:
+    visible: "Your feed is empty|Discover People"
+    timeout: 10000
+    optional: true
+
+# Scroll through the feed
+- scroll
+- scroll

--- a/.maestro/flows/login.yaml
+++ b/.maestro/flows/login.yaml
@@ -1,0 +1,31 @@
+appId: com.malinmw.wellingtonapp
+
+# Reusable login subflow — logs in as "You" seed user via Dev Login
+# Usage: - runFlow: flows/login.yaml
+
+---
+- launchApp
+
+# Wait for login screen
+- assertVisible:
+    id: "login-screen"
+
+# Open dev login modal via testID
+- tapOn:
+    id: "dev-login-trigger"
+
+# Wait for seed users to appear
+- extendedWaitUntil:
+    visible:
+      id: "seed-user-you"
+    timeout: 5000
+
+# Tap "You" seed user via testID
+- tapOn:
+    id: "seed-user-you"
+
+# Wait for login to complete — login screen should disappear
+- extendedWaitUntil:
+    notVisible:
+      id: "login-screen"
+    timeout: 10000

--- a/.maestro/login.yaml
+++ b/.maestro/login.yaml
@@ -1,0 +1,32 @@
+appId: com.malinmw.wellingtonapp
+name: "Login - Dev login with seed user"
+tags:
+  - auth
+  - smoke
+
+---
+- launchApp
+
+# Assert login screen is visible
+- assertVisible:
+    id: "login-screen"
+
+# Open dev login modal via testID
+- tapOn:
+    id: "dev-login-trigger"
+
+# Wait for seed users to appear
+- extendedWaitUntil:
+    visible:
+      id: "seed-user-you"
+    timeout: 5000
+
+# Tap "You" seed user via testID
+- tapOn:
+    id: "seed-user-you"
+
+# Assert we've left the login screen
+- extendedWaitUntil:
+    notVisible:
+      id: "login-screen"
+    timeout: 10000

--- a/.maestro/profile.yaml
+++ b/.maestro/profile.yaml
@@ -1,0 +1,19 @@
+appId: com.malinmw.wellingtonapp
+name: "Profile - View profile screen"
+tags:
+  - profile
+
+---
+
+# Log in first
+- runFlow: flows/login.yaml
+
+# Navigate to Profile tab
+- tapOn: "Profile"
+
+# Assert profile elements are visible
+- assertVisible: "Edit Profile"
+- assertVisible: "Find People"
+- assertVisible: "Posts"
+- assertVisible: "Followers"
+- assertVisible: "Following"

--- a/.maestro/search.yaml
+++ b/.maestro/search.yaml
@@ -1,0 +1,20 @@
+appId: com.malinmw.wellingtonapp
+name: "Search - Search interaction"
+tags:
+  - search
+
+---
+# Log in first
+- runFlow: flows/login.yaml
+
+# Navigate to Search tab
+- tapOn: "Search"
+
+# Wait for search screen to load — assert browse content is visible
+- assertVisible: "Trending"
+- assertVisible: "Browse by Category"
+
+# Tap on a trending search chip to trigger a search
+- tapOn: chart line, Coffee
+
+- assertVisible: cup.and.saucer.fill, Customs by Coffee Supreme, 39 Ghuznee Street, Te Aro, Forward

--- a/.maestro/tab-navigation.yaml
+++ b/.maestro/tab-navigation.yaml
@@ -1,0 +1,26 @@
+appId: com.malinmw.wellingtonapp
+name: "Tab Navigation - Navigate all 5 tabs"
+tags:
+  - navigation
+  - smoke
+
+---
+
+# Log in first
+- runFlow: flows/login.yaml
+
+# Map tab should be active by default (first tab)
+# Navigate to Feed tab
+- tapOn: "Feed"
+
+# Navigate to Events tab
+- tapOn: "Events"
+
+# Navigate to Profile tab
+- tapOn: "Profile"
+
+# Navigate to Search tab
+- tapOn: "Search"
+
+# Navigate back to Map tab
+- tapOn: "Map"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "db:link:production": "supabase link --project-ref cxipwnwxvkguxtbzvnlz",
     "lint": "eslint . && deno lint --config supabase/functions/deno.json supabase/functions/",
     "typecheck": "tsc --noEmit && deno check --config supabase/functions/deno.json supabase/functions/*/index.ts",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "e2e": "maestro test .maestro/",
+    "e2e:login": "maestro test .maestro/login.yaml"
   },
   "dependencies": {
     "@expo-google-fonts/pacifico": "^0.4.1",

--- a/src/components/HapticPressable.tsx
+++ b/src/components/HapticPressable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { GestureResponderEvent, Pressable, PressableProps } from 'react-native';
 import * as Haptics from 'expo-haptics';
 
-export const HapticPressable = ({ onPress, children, style }: PressableProps) => {
+export const HapticPressable = ({ onPress, children, style, ...rest }: PressableProps) => {
     const handlePress = (event: GestureResponderEvent) => {
         // Trigger haptic feedback
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -16,6 +16,7 @@ export const HapticPressable = ({ onPress, children, style }: PressableProps) =>
                 typeof style === 'function' ? style(state) : style,
                 state.pressed && { opacity: 0.7 }
             ]}
+            {...rest}
         >
             {children}
         </Pressable>

--- a/src/screens/EventsScreen.tsx
+++ b/src/screens/EventsScreen.tsx
@@ -274,6 +274,7 @@ export function EventsScreen() {
   return (
     <View style={styles.container}>
       <SectionList
+        testID="events-list"
         sections={sections}
         keyExtractor={(item) => item.event.id}
         renderItem={({ item }) => (

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -133,6 +133,7 @@ export function FeedScreen() {
   return (
     <View style={styles.container}>
       <FlatList
+        testID="feed-list"
         data={postsWithData}
         keyExtractor={(item) => item.post.id}
         renderItem={renderItem}

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -8,7 +8,6 @@ import {
   Platform,
   ActivityIndicator,
   Alert,
-  Modal,
   useWindowDimensions,
 } from "react-native";
 import { Image } from "expo-image";
@@ -23,22 +22,14 @@ import { Ionicons } from "@expo/vector-icons";
 import { SFSymbol } from "expo-symbols";
 import { SFIcon } from "../components/SFIcon";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import {
-  Gesture,
-  GestureDetector,
-  GestureHandlerRootView,
-} from "react-native-gesture-handler";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import Reanimated, {
   useSharedValue,
   useAnimatedStyle,
-  withSpring,
   withTiming,
-  withRepeat,
   withSequence,
   Easing,
   interpolate,
-  runOnJS,
-  cancelAnimation,
 } from "react-native-reanimated";
 import { fonts } from "../theme/fonts";
 import { signInWithGoogle, signInWithApple } from "../services/auth";
@@ -129,11 +120,6 @@ export function LoginScreen() {
     null
   );
   const [showDevModal, setShowDevModal] = useState(false);
-  const translateY = useSharedValue(600);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: translateY.value }],
-  }));
 
   // Carousel — two stable layers (A/B) that flip-flop roles.
   // The visible layer never changes source; only the hidden one gets a new URI.
@@ -254,27 +240,11 @@ export function LoginScreen() {
 
   const openDevModal = () => {
     setShowDevModal(true);
-    translateY.value = withSpring(0, { damping: 20, stiffness: 90 });
   };
 
   const closeDevModal = () => {
-    translateY.value = withSpring(600, { damping: 20, stiffness: 90 });
-    setTimeout(() => setShowDevModal(false), 300);
+    setShowDevModal(false);
   };
-
-  const panGesture = Gesture.Pan()
-    .onUpdate((event) => {
-      if (event.translationY > 0) {
-        translateY.value = event.translationY;
-      }
-    })
-    .onEnd((event) => {
-      if (event.translationY > 150 || event.velocityY > 500) {
-        runOnJS(closeDevModal)();
-      } else {
-        translateY.value = withSpring(0, { damping: 20, stiffness: 90 });
-      }
-    });
 
   const renderButton = (
     onPress: () => void,
@@ -328,7 +298,7 @@ export function LoginScreen() {
   const renderDevTrigger = () => {
     if (glassEnabled) {
       return (
-        <HapticPressable style={styles.devTrigger} onPress={openDevModal}>
+        <HapticPressable testID="dev-login-trigger" style={styles.devTrigger} onPress={openDevModal}>
           <GlassView
             isInteractive
             style={styles.devTriggerGlass}
@@ -346,7 +316,7 @@ export function LoginScreen() {
     }
 
     return (
-      <HapticPressable style={styles.devTrigger} onPress={openDevModal}>
+      <HapticPressable testID="dev-login-trigger" style={styles.devTrigger} onPress={openDevModal}>
         <BlurView intensity={60} style={styles.devTriggerFallback}>
           <Ionicons
             name="code-slash"
@@ -359,54 +329,38 @@ export function LoginScreen() {
     );
   };
 
-  const renderDevModalInner = () => {
-    const inner = (
-      <>
-        <View style={styles.dragHandle} />
-        <Text style={styles.devTitle}>Dev Login</Text>
-        <ScrollView contentContainerStyle={styles.seedGrid}>
-          {SEED_USERS.map((user) => (
-            <HapticPressable
-              key={user.email}
-              style={styles.seedUser}
-              onPress={() => {
-                handleSeedLogin(user.email);
-                closeDevModal();
-              }}
-              disabled={loading !== null}
-            >
-              <Image source={{ uri: user.avatar }} style={styles.seedAvatar} contentFit="cover" transition={200} />
-              {loading === user.email ? (
-                <ActivityIndicator
-                  size="small"
-                  color="#fff"
-                  style={styles.seedSpinner}
-                />
-              ) : (
-                <Text style={styles.seedName} numberOfLines={1}>
-                  {user.name}
-                </Text>
-              )}
-            </HapticPressable>
-          ))}
-        </ScrollView>
-      </>
-    );
-
-    if (glassEnabled) {
-      return <GlassView style={styles.devModalGlass}>{inner}</GlassView>;
-    }
-
-    return (
-      <BlurView intensity={100} style={styles.devModalBlur}>
-        {inner}
-      </BlurView>
-    );
-  };
+  const renderDevModalInner = () => (
+    <View>
+      <Text style={styles.devTitle}>Dev Login</Text>
+      <ScrollView testID="dev-modal" contentContainerStyle={styles.seedGrid}>
+        {SEED_USERS.map((user) => (
+          <Pressable
+            key={user.email}
+            testID={`seed-user-${user.name.toLowerCase().replace(/[^a-z]/g, "-")}`}
+            style={styles.seedUser}
+            onPress={() => {
+              handleSeedLogin(user.email);
+              closeDevModal();
+            }}
+            disabled={loading !== null}
+          >
+            <Image source={{ uri: user.avatar }} style={styles.seedAvatar} contentFit="cover" transition={200} />
+            {loading === user.email ? (
+              <ActivityIndicator size="small" color="#fff" style={styles.seedSpinner} />
+            ) : (
+              <Text style={styles.seedName} numberOfLines={1}>
+                {user.name}
+              </Text>
+            )}
+          </Pressable>
+        ))}
+      </ScrollView>
+    </View>
+  );
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <View style={styles.backgroundImage}>
+      <View testID="login-screen" style={styles.backgroundImage}>
         {/* Layer A */}
         <Reanimated.Image
           source={{ uri: layerA }}
@@ -455,7 +409,7 @@ export function LoginScreen() {
             <View style={{ flex: 1 }} />
 
             {/* Title anchored above buttons */}
-            <Text style={styles.title}>Welly</Text>
+            <Text testID="login-title" style={styles.title}>Welly</Text>
 
             {/* Buttons */}
             <View style={styles.buttons}>
@@ -502,21 +456,12 @@ export function LoginScreen() {
         </LinearGradient>
       </View>
 
-      {/* Dev Login Modal */}
-      <Modal
-        visible={showDevModal}
-        transparent
-        animationType="fade"
-        onRequestClose={closeDevModal}
-      >
-        <Pressable style={styles.modalOverlay} onPress={closeDevModal}>
-          <GestureDetector gesture={panGesture}>
-            <Reanimated.View style={[styles.modalContent, animatedStyle]}>
-              {renderDevModalInner()}
-            </Reanimated.View>
-          </GestureDetector>
-        </Pressable>
-      </Modal>
+      {/* Dev Login - full screen overlay */}
+      {showDevModal && (
+        <View style={styles.devOverlay}>
+          {renderDevModalInner()}
+        </View>
+      )}
     </GestureHandlerRootView>
   );
 }
@@ -620,40 +565,12 @@ const styles = StyleSheet.create({
     color: "rgba(255, 255, 255, 0.7)",
     letterSpacing: 0.3,
   },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0, 0, 0, 0.5)",
-    justifyContent: "flex-end",
-  },
-  modalContent: {
-    width: "100%",
-    maxHeight: "70%",
-    borderTopLeftRadius: 32,
-    borderTopRightRadius: 32,
-    overflow: "hidden",
-  },
-  devModalGlass: {
-    paddingTop: 20,
-    paddingBottom: 40,
+  devOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 10,
+    backgroundColor: "rgba(20, 20, 20, 0.97)",
+    justifyContent: "center",
     paddingHorizontal: 24,
-    borderTopLeftRadius: 32,
-    borderTopRightRadius: 32,
-  },
-  devModalBlur: {
-    paddingTop: 20,
-    paddingBottom: 40,
-    paddingHorizontal: 24,
-    backgroundColor: "rgba(255, 255, 255, 0.1)",
-    borderTopWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.2)",
-  },
-  dragHandle: {
-    width: 36,
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: "rgba(255, 255, 255, 0.4)",
-    alignSelf: "center",
-    marginBottom: 24,
   },
   devTitle: {
     fontSize: 13,

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -149,6 +149,7 @@ export function ProfileScreen() {
 
   return (
     <ScrollView
+      testID="profile-screen"
       style={styles.container}
       showsVerticalScrollIndicator={false}
       refreshControl={
@@ -171,11 +172,11 @@ export function ProfileScreen() {
         ) : (
           <Image source={{ uri: currentUser.avatarUrl }} style={styles.avatar} contentFit="cover" transition={200} onError={() => setAvatarError(true)} />
         )}
-        <Text style={styles.displayName}>{currentUser.displayName}</Text>
-        <Text style={styles.username}>@{currentUser.username}</Text>
+        <Text testID="profile-display-name" style={styles.displayName}>{currentUser.displayName}</Text>
+        <Text testID="profile-username" style={styles.username}>@{currentUser.username}</Text>
         {currentUser.bio && <Text style={styles.bio}>{currentUser.bio}</Text>}
 
-        <View style={styles.statsRow}>
+        <View testID="profile-stats" style={styles.statsRow}>
           <View style={styles.stat}>
             <Text style={styles.statNumber}>{postCount}</Text>
             <Text style={styles.statLabel}>Posts</Text>


### PR DESCRIPTION
## Summary
- Add Maestro YAML-based e2e tests covering critical user flows: login, tab navigation, feed, profile, search, and events
- Add `testID` props to key interactive elements across screens for reliable test targeting
- Simplify dev login modal (replace animated Modal with plain full-screen overlay) for Maestro compatibility
- Fix `HapticPressable` to pass through all props (testID, disabled, etc.) instead of dropping them
- Add `npm run e2e` and `npm run e2e:login` scripts

## Test plan
- [ ] Build iOS dev client: `npx expo run:ios`
- [ ] Run all e2e tests: `npm run e2e`
- [ ] Run login test only: `npm run e2e:login`
- [ ] Verify CI passes: `npm run typecheck && npm run lint && npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)