### PR TITLE
fix: prevent place detail sheets from stacking on marker tap

### DIFF
--- a/app/(tabs)/map/_layout.tsx
+++ b/app/(tabs)/map/_layout.tsx
@@ -1,5 +1,6 @@
 import { Stack } from "expo-router";
 import { ErrorScreen } from "../../../src/components/ErrorScreen";
+import { MapPlaceSelectionProvider } from "../../../src/context/MapPlaceSelectionContext";
 
 export function ErrorBoundary({ error, retry }: { error: Error; retry: () => void }) {
   return <ErrorScreen error={error} retry={retry} />;
@@ -7,6 +8,7 @@ export function ErrorBoundary({ error, retry }: { error: Error; retry: () => voi
 
 export default function MapLayout() {
   return (
+    <MapPlaceSelectionProvider>
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="(drawer)" />
       <Stack.Screen
@@ -111,5 +113,6 @@ export default function MapLayout() {
         }}
       />
     </Stack>
+    </MapPlaceSelectionProvider>
   );
 }

--- a/src/context/MapPlaceSelectionContext.tsx
+++ b/src/context/MapPlaceSelectionContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useState, useCallback, useRef } from "react";
+
+interface MapPlaceSelectionContextType {
+  selectedPlaceId: string | null;
+  selectPlace: (placeId: string) => void;
+  sheetOpenRef: React.MutableRefObject<boolean>;
+}
+
+const MapPlaceSelectionContext = createContext<MapPlaceSelectionContextType | null>(null);
+
+export function MapPlaceSelectionProvider({ children }: { children: React.ReactNode }) {
+  const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
+  const sheetOpenRef = useRef(false);
+
+  const selectPlace = useCallback((placeId: string) => {
+    setSelectedPlaceId(placeId);
+  }, []);
+
+  return (
+    <MapPlaceSelectionContext.Provider value={{ selectedPlaceId, selectPlace, sheetOpenRef }}>
+      {children}
+    </MapPlaceSelectionContext.Provider>
+  );
+}
+
+export function useMapPlaceSelection() {
+  const ctx = useContext(MapPlaceSelectionContext);
+  if (!ctx) throw new Error("useMapPlaceSelection must be used within MapPlaceSelectionProvider");
+  return ctx;
+}

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -34,6 +34,7 @@ import { useRouter } from "expo-router";
 import { colors } from "../theme/colors";
 import { fonts } from "../theme/fonts";
 import { FloatingCreateButton } from "src/components/FloatingCreateButton";
+import { useMapPlaceSelection } from "../context/MapPlaceSelectionContext";
 import * as Haptics from "expo-haptics";
 
 interface MapMarkerItemProps {
@@ -98,6 +99,7 @@ export function MapScreen() {
   const router = useRouter();
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
+  const { selectPlace, sheetOpenRef } = useMapPlaceSelection();
   const { followingIds } = useFollow();
   const { selectedCategories, showFollowingOnly, showTrails, showEvents } =
     useMapFilters();
@@ -130,14 +132,16 @@ export function MapScreen() {
 
   const openPlaceSheet = useCallback(
     (placeId: string) => {
-      const path = `/map/place-posts/${placeId}` as const;
       if (activeTrailId) {
         setActiveTrailId(null);
         router.dismiss();
       }
-      router.push(path);
+      selectPlace(placeId);
+      if (!sheetOpenRef.current) {
+        router.push(`/map/place-posts/${placeId}`);
+      }
     },
-    [router, activeTrailId]
+    [router, activeTrailId, selectPlace, sheetOpenRef]
   );
 
   const handleMarkerPress = useCallback(
@@ -200,10 +204,13 @@ export function MapScreen() {
   const handleTrailPress = useCallback(
     (trailId: string) => {
       setActiveTrailId(trailId);
-      if (router.canDismiss()) router.dismiss();
+      if (sheetOpenRef.current) {
+        sheetOpenRef.current = false;
+        router.dismiss();
+      }
       router.push(`/map/trail/${trailId}`);
     },
-    [router]
+    [router, sheetOpenRef]
   );
 
   const activeFilterCount =

--- a/src/screens/PlacePostsSheetScreen.tsx
+++ b/src/screens/PlacePostsSheetScreen.tsx
@@ -13,6 +13,7 @@ import { SFIcon } from "../components/SFIcon";
 import { useLocalSearchParams, useRouter, useFocusEffect } from "expo-router";
 import { useFollow } from "../context/FollowContext";
 import { useLike } from "../context/LikeContext";
+import { useMapPlaceSelection } from "../context/MapPlaceSelectionContext";
 import { useQuery } from "../hooks/useQuery";
 import { getPlaceById } from "../services/places";
 import { getPostsByPlaceId } from "../services/posts";
@@ -41,10 +42,19 @@ const CATEGORY_LABELS: Record<PlaceCategory, string> = {
 };
 
 export function PlacePostsSheetScreen() {
-  const { placeId } = useLocalSearchParams<{ placeId: string }>();
+  const { placeId: routePlaceId } = useLocalSearchParams<{ placeId: string }>();
+  const { selectedPlaceId, sheetOpenRef } = useMapPlaceSelection();
+  const placeId = selectedPlaceId ?? routePlaceId;
   const router = useRouter();
   const { followingIds } = useFollow();
   const { getLikeCount } = useLike();
+
+  useEffect(() => {
+    sheetOpenRef.current = true;
+    return () => {
+      sheetOpenRef.current = false;
+    };
+  }, [sheetOpenRef]);
 
   const fetchPlace = useCallback(() => getPlaceById(placeId!), [placeId]);
   const fetchPosts = useCallback(() => getPostsByPlaceId(placeId!), [placeId]);


### PR DESCRIPTION
## Summary
- Place detail form sheets were stacking when tapping different map markers instead of updating in place
- Added `MapPlaceSelectionContext` to share the selected place ID between `MapScreen` and `PlacePostsSheetScreen`
- The sheet is only pushed once; subsequent marker taps update the content via context
- Trail/place sheet transitions properly dismiss before pushing the new sheet

## Test plan
- [ ] Tap a map marker — place sheet opens
- [ ] Tap a different marker while sheet is open — content updates without stacking
- [ ] Tap a trail while place sheet is open — place sheet dismisses, trail sheet opens
- [ ] Tap a marker while trail sheet is open — trail sheet dismisses, place sheet opens
- [ ] Dismiss the sheet and tap a marker again — sheet opens normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)