### PR TITLE
refactor: auto-detect post type from attached media

### DIFF
--- a/src/components/create/PostForm.tsx
+++ b/src/components/create/PostForm.tsx
@@ -1,24 +1,11 @@
 import React, { useEffect, useRef, useState } from "react";
 import { View, Text, TextInput, ScrollView, StyleSheet } from "react-native";
 import { Image } from "expo-image";
-import { Ionicons } from "@expo/vector-icons";
-import { SFSymbol } from "expo-symbols";
 import * as ExpoVideoThumbnails from "expo-video-thumbnails";
 import { SFIcon } from "../SFIcon";
 import { HapticPressable } from "../HapticPressable";
 import { VideoThumbnail } from "../VideoThumbnail";
-import { PostType } from "../../types";
 import { colors } from "../../theme/colors";
-
-const POST_TYPES: {
-  type: PostType;
-  icon: { sf: SFSymbol; fallback: keyof typeof Ionicons.glyphMap };
-  label: string;
-}[] = [
-  { type: "photo", icon: { sf: "photo.fill", fallback: "image" }, label: "Photo" },
-  { type: "video", icon: { sf: "video.fill", fallback: "videocam" }, label: "Video" },
-  { type: "text", icon: { sf: "doc.text.fill", fallback: "document-text" }, label: "Text" },
-];
 
 const MAX_CONTENT_LENGTH = 500;
 const MAX_MEDIA_ITEMS = 5;
@@ -34,8 +21,6 @@ interface PostFormProps {
   avatarUrl?: string;
   content: string;
   onContentChange: (text: string) => void;
-  postType: PostType;
-  onPostTypeChange: (type: PostType) => void;
   mediaItems: MediaPickerItem[];
   onPickMedia: () => void;
   onRemoveMedia: (index: number) => void;
@@ -45,8 +30,6 @@ export function PostForm({
   avatarUrl,
   content,
   onContentChange,
-  postType,
-  onPostTypeChange,
   mediaItems,
   onPickMedia,
   onRemoveMedia,
@@ -97,44 +80,8 @@ export function PostForm({
         </View>
       </View>
 
-      {/* Post Type Selector - compact pills */}
-      <View style={styles.typePillRow}>
-        {POST_TYPES.map((item) => (
-          <HapticPressable
-            key={item.type}
-            style={[
-              styles.typePill,
-              postType === item.type && styles.typePillActive,
-            ]}
-            onPress={() => {
-              onPostTypeChange(item.type);
-              // Clear all media when switching types
-              for (let i = mediaItems.length - 1; i >= 0; i--) {
-                onRemoveMedia(i);
-              }
-            }}
-          >
-            <SFIcon
-              name={item.icon.sf}
-              fallback={item.icon.fallback}
-              size={16}
-              color={postType === item.type ? colors.primary : colors.gray500}
-            />
-            <Text
-              style={[
-                styles.typePillLabel,
-                postType === item.type && styles.typePillLabelActive,
-              ]}
-            >
-              {item.label}
-            </Text>
-          </HapticPressable>
-        ))}
-      </View>
-
       {/* Media Section */}
-      {postType !== "text" &&
-        (hasMedia ? (
+      {hasMedia ? (
           <View style={styles.mediaStripContainer}>
             <ScrollView
               horizontal
@@ -184,7 +131,7 @@ export function PostForm({
               Add photos & videos
             </Text>
           </HapticPressable>
-        ))}
+        )}
     </>
   );
 }
@@ -227,30 +174,6 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     textAlign: "right",
     marginTop: 2,
-  },
-  typePillRow: {
-    flexDirection: "row",
-    gap: 8,
-    marginTop: 20,
-  },
-  typePill: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 20,
-  },
-  typePillActive: {
-    backgroundColor: colors.primary + "12",
-  },
-  typePillLabel: {
-    fontSize: 14,
-    fontFamily: "PlusJakartaSans_500Medium",
-    color: colors.gray500,
-  },
-  typePillLabelActive: {
-    color: colors.primary,
   },
   mediaButton: {
     alignItems: "center",

--- a/src/screens/CreatePostSheetScreen.tsx
+++ b/src/screens/CreatePostSheetScreen.tsx
@@ -65,9 +65,15 @@ export function CreatePostSheetScreen() {
   );
 
   // Post-specific state
-  const [postType, setPostType] = useState<PostType>("photo");
   const [content, setContent] = useState("");
   const [mediaItems, setMediaItems] = useState<MediaPickerItem[]>([]);
+
+  // Derive post type from attached media
+  const getPostType = (): PostType => {
+    if (mediaItems.length === 0) return "text";
+    if (mediaItems.some((item) => item.type === "video")) return "video";
+    return "photo";
+  };
 
   // Event-specific state
   const [eventTitle, setEventTitle] = useState("");
@@ -145,12 +151,8 @@ export function CreatePostSheetScreen() {
     delete (global as any).__sharedIntent;
 
     if (shared.mediaFiles && shared.mediaFiles.length > 0) {
-      // Multi-file share
-      const hasVideo = shared.mediaFiles.some((f) => f.type === 'video');
-      setPostType(hasVideo ? 'video' : 'photo');
       setMediaItems(shared.mediaFiles);
     } else if (shared.videoUri) {
-      setPostType("video");
       setMediaItems([{
         uri: shared.videoUri,
         type: 'video',
@@ -158,7 +160,6 @@ export function CreatePostSheetScreen() {
         height: shared.mediaHeight,
       }]);
     } else if (shared.imageUri) {
-      setPostType("photo");
       setMediaItems([{
         uri: shared.imageUri,
         type: 'photo',
@@ -290,6 +291,8 @@ export function CreatePostSheetScreen() {
           mediaHeight?: number;
           sortOrder: number;
         }> | undefined;
+
+        const postType = getPostType();
 
         if (mediaItems.length > 0 && postType !== "text") {
           // Compress and upload all media in parallel
@@ -522,8 +525,6 @@ export function CreatePostSheetScreen() {
                 avatarUrl={profile?.avatarUrl}
                 content={content}
                 onContentChange={setContent}
-                postType={postType}
-                onPostTypeChange={setPostType}
                 mediaItems={mediaItems}
                 onPickMedia={pickMedia}
                 onRemoveMedia={(index) => {


### PR DESCRIPTION
## Summary
- Removed the manual Photo/Video/Text type selector pills from the create post form
- Post type is now derived automatically from attached media: no media → `text`, has video → `video`, photos only → `photo`
- Simplifies the post creation flow — one less decision for the user

## Test plan
- [ ] Create a post with photos only — should save as `photo` type
- [ ] Create a post with a video — should save as `video` type
- [ ] Create a post with no media — should save as `text` type
- [ ] Create a post with mixed photos and videos — should save as `video` type
- [ ] Share media into the app from another app — post type should be set correctly
- [ ] Verify the type selector pills no longer appear in the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)