### PR TITLE
feat: add guides — curated place lists

### DIFF
--- a/app/(tabs)/events/_layout.tsx
+++ b/app/(tabs)/events/_layout.tsx
@@ -79,6 +79,15 @@ export default function EventsLayout() {
             headerTransparent: true,
           }}
         />
+        <Stack.Screen
+          name="guide/[guideId]"
+          options={{
+            headerShown: true,
+            headerTitle: "",
+            headerBackTitle: "Events",
+            headerTransparent: true,
+          }}
+        />
       </Stack>
     </EventFilterProvider>
   );

--- a/app/(tabs)/events/guide/[guideId].tsx
+++ b/app/(tabs)/events/guide/[guideId].tsx
@@ -1,0 +1,1 @@
+export { GuideDetailScreen as default } from '../../../../src/screens/GuideDetailScreen';

--- a/app/(tabs)/feed/_layout.tsx
+++ b/app/(tabs)/feed/_layout.tsx
@@ -136,6 +136,15 @@ export default function FeedLayout() {
           headerTransparent: true,
         }}
       />
+      <Stack.Screen
+        name="guide/[guideId]"
+        options={{
+          headerShown: true,
+          headerTitle: "",
+          headerBackTitle: "Feed",
+          headerTransparent: true,
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(tabs)/feed/guide/[guideId].tsx
+++ b/app/(tabs)/feed/guide/[guideId].tsx
@@ -1,0 +1,1 @@
+export { GuideDetailScreen as default } from '../../../../src/screens/GuideDetailScreen';

--- a/app/(tabs)/map/_layout.tsx
+++ b/app/(tabs)/map/_layout.tsx
@@ -121,6 +121,15 @@ export default function MapLayout() {
           headerTransparent: true,
         }}
       />
+      <Stack.Screen
+        name="guide/[guideId]"
+        options={{
+          headerShown: true,
+          headerTitle: "",
+          headerBackTitle: "Map",
+          headerTransparent: true,
+        }}
+      />
     </Stack>
     </MapPlaceSelectionProvider>
   );

--- a/app/(tabs)/map/guide/[guideId].tsx
+++ b/app/(tabs)/map/guide/[guideId].tsx
@@ -1,0 +1,1 @@
+export { GuideDetailScreen as default } from '../../../../src/screens/GuideDetailScreen';

--- a/app/(tabs)/profile/_layout.tsx
+++ b/app/(tabs)/profile/_layout.tsx
@@ -283,6 +283,38 @@ export default function ProfileLayout() {
           headerTransparent: true,
         }}
       />
+      <Stack.Screen
+        name="guides"
+        options={{
+          headerShown: true,
+          headerTitle: "Guides",
+          headerBackTitle: "Profile",
+          headerTransparent: true,
+        }}
+      />
+      <Stack.Screen
+        name="guide/[guideId]"
+        options={{
+          headerShown: true,
+          headerTitle: "",
+          headerBackTitle: "Guides",
+          headerTransparent: true,
+        }}
+      />
+      <Stack.Screen
+        name="create-guide"
+        options={{
+          presentation: "formSheet",
+          headerShown: false,
+          contentStyle: { backgroundColor: "transparent" },
+          sheetAllowedDetents: [0.95, 1.0],
+          sheetGrabberVisible: true,
+          sheetCornerRadius: 32,
+          sheetInitialDetentIndex: 0,
+          sheetLargestUndimmedDetentIndex: 0,
+          sheetExpandsWhenScrolledToEdge: false,
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(tabs)/profile/create-guide.tsx
+++ b/app/(tabs)/profile/create-guide.tsx
@@ -1,0 +1,1 @@
+export { CreateGuideScreen as default } from '../../../src/screens/CreateGuideScreen';

--- a/app/(tabs)/profile/guide/[guideId].tsx
+++ b/app/(tabs)/profile/guide/[guideId].tsx
@@ -1,0 +1,1 @@
+export { GuideDetailScreen as default } from '../../../../src/screens/GuideDetailScreen';

--- a/app/(tabs)/profile/guides.tsx
+++ b/app/(tabs)/profile/guides.tsx
@@ -1,0 +1,1 @@
+export { GuidesListScreen as default } from '../../../src/screens/GuidesListScreen';

--- a/app/(tabs)/search/_layout.tsx
+++ b/app/(tabs)/search/_layout.tsx
@@ -68,6 +68,15 @@ export default function SearchLayout() {
           headerTransparent: true,
         }}
       />
+      <Stack.Screen
+        name="guide/[guideId]"
+        options={{
+          headerShown: true,
+          headerTitle: "",
+          headerBackTitle: "Search",
+          headerTransparent: true,
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(tabs)/search/guide/[guideId].tsx
+++ b/app/(tabs)/search/guide/[guideId].tsx
@@ -1,0 +1,1 @@
+export { GuideDetailScreen as default } from '../../../../src/screens/GuideDetailScreen';

--- a/src/components/GuideCard.tsx
+++ b/src/components/GuideCard.tsx
@@ -1,0 +1,197 @@
+import React, { useCallback } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Image } from "expo-image";
+import { LinearGradient } from "expo-linear-gradient";
+import { SFIcon } from "./SFIcon";
+import { HapticPressable } from "./HapticPressable";
+import { useQuery } from "../hooks/useQuery";
+import { getProfileById } from "../services/users";
+import { colors } from "../theme/colors";
+import { fonts } from "../theme/fonts";
+import type { Guide } from "../types";
+
+interface GuideCardProps {
+  guide: Guide;
+  onPress?: () => void;
+  compact?: boolean;
+}
+
+export function GuideCard({ guide, onPress, compact }: GuideCardProps) {
+  const fetchCreator = useCallback(
+    () => getProfileById(guide.userId),
+    [guide.userId]
+  );
+  const { data: creator } = useQuery(fetchCreator, ["user", guide.userId]);
+
+  return (
+    <HapticPressable
+      style={[styles.container, compact && styles.containerCompact]}
+      onPress={onPress}
+    >
+      {guide.coverImageUrl ? (
+        <View style={[styles.imageContainer, compact && styles.imageContainerCompact]}>
+          <Image
+            source={{ uri: guide.coverImageUrl }}
+            style={styles.image}
+            contentFit="cover"
+            transition={200}
+          />
+          <LinearGradient
+            colors={["transparent", "rgba(0,0,0,0.7)"]}
+            start={{ x: 0, y: 0.3 }}
+            end={{ x: 0, y: 1 }}
+            style={styles.imageGradient}
+          />
+          <Text style={styles.titleOverlay} numberOfLines={2}>
+            {guide.title}
+          </Text>
+        </View>
+      ) : (
+        <View style={[styles.placeholderHeader, compact && styles.placeholderHeaderCompact]}>
+          <SFIcon
+            name="book.fill"
+            fallback="book"
+            size={compact ? 20 : 24}
+            color="#FFFFFF"
+          />
+          <Text
+            style={[styles.titlePlaceholder, compact && styles.titlePlaceholderCompact]}
+            numberOfLines={2}
+          >
+            {guide.title}
+          </Text>
+        </View>
+      )}
+
+      <View style={styles.footer}>
+        <View style={styles.creatorRow}>
+          {creator?.avatarUrl ? (
+            <Image
+              source={{ uri: creator.avatarUrl }}
+              style={styles.creatorAvatar}
+              contentFit="cover"
+              transition={200}
+            />
+          ) : (
+            <View style={[styles.creatorAvatar, styles.creatorAvatarFallback]}>
+              <SFIcon name="person.fill" fallback="person" size={10} color={colors.textMuted} />
+            </View>
+          )}
+          <Text style={styles.creatorName} numberOfLines={1}>
+            {creator?.displayName ?? ""}
+          </Text>
+        </View>
+        <View style={styles.placeCount}>
+          <SFIcon
+            name="mappin.and.ellipse"
+            fallback="location"
+            size={12}
+            color={colors.textSecondary}
+          />
+          <Text style={styles.placeCountText}>
+            {guide.placeCount} {guide.placeCount === 1 ? "place" : "places"}
+          </Text>
+        </View>
+      </View>
+    </HapticPressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.cardBackground,
+    borderRadius: 12,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  containerCompact: {
+    width: 200,
+  },
+  imageContainer: {
+    height: 140,
+    position: "relative",
+  },
+  imageContainerCompact: {
+    height: 110,
+  },
+  image: {
+    width: "100%",
+    height: "100%",
+    backgroundColor: colors.gray200,
+  },
+  imageGradient: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: "60%",
+  },
+  titleOverlay: {
+    position: "absolute",
+    bottom: 10,
+    left: 12,
+    right: 12,
+    fontSize: 16,
+    fontFamily: fonts.bold,
+    color: "#FFFFFF",
+    textShadowColor: "rgba(0,0,0,0.5)",
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 4,
+  },
+  placeholderHeader: {
+    height: 140,
+    backgroundColor: colors.primary,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+    gap: 8,
+  },
+  placeholderHeaderCompact: {
+    height: 110,
+  },
+  titlePlaceholder: {
+    fontSize: 16,
+    fontFamily: fonts.bold,
+    color: "#FFFFFF",
+    textAlign: "center",
+  },
+  titlePlaceholderCompact: {
+    fontSize: 14,
+  },
+  footer: {
+    padding: 12,
+    gap: 6,
+  },
+  creatorRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  creatorAvatar: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: colors.gray200,
+  },
+  creatorAvatarFallback: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  creatorName: {
+    fontSize: 13,
+    fontFamily: fonts.medium,
+    color: colors.text,
+    flex: 1,
+  },
+  placeCount: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  placeCountText: {
+    fontSize: 12,
+    fontFamily: fonts.medium,
+    color: colors.textSecondary,
+  },
+});

--- a/src/context/SaveContext.tsx
+++ b/src/context/SaveContext.tsx
@@ -20,14 +20,16 @@ export function SaveProvider({ children }: { children: React.ReactNode }) {
   const [savedPosts, setSavedPosts] = useState<string[]>([]);
   const [savedPlaces, setSavedPlaces] = useState<string[]>([]);
   const [savedEvents, setSavedEvents] = useState<string[]>([]);
+  const [savedGuides, setSavedGuides] = useState<string[]>([]);
 
   const refreshFromServer = useCallback(() => {
     if (!currentUserId) return;
     getSavedItemIds(currentUserId)
-      .then(({ posts, places, events }) => {
+      .then(({ posts, places, events, guides }) => {
         setSavedPosts(posts);
         setSavedPlaces(places);
         setSavedEvents(events);
+        setSavedGuides(guides);
       })
       .catch(() => {});
   }, [currentUserId]);
@@ -37,6 +39,7 @@ export function SaveProvider({ children }: { children: React.ReactNode }) {
       setSavedPosts([]);
       setSavedPlaces([]);
       setSavedEvents([]);
+      setSavedGuides([]);
       return;
     }
     refreshFromServer();
@@ -53,6 +56,7 @@ export function SaveProvider({ children }: { children: React.ReactNode }) {
   const getSetterForType = (type: SavedItemType) => {
     if (type === 'post') return setSavedPosts;
     if (type === 'place') return setSavedPlaces;
+    if (type === 'guide') return setSavedGuides;
     return setSavedEvents;
   };
 
@@ -60,9 +64,10 @@ export function SaveProvider({ children }: { children: React.ReactNode }) {
     (type: SavedItemType) => {
       if (type === 'post') return savedPosts;
       if (type === 'place') return savedPlaces;
+      if (type === 'guide') return savedGuides;
       return savedEvents;
     },
-    [savedPosts, savedPlaces, savedEvents]
+    [savedPosts, savedPlaces, savedEvents, savedGuides]
   );
 
   const isSaved = useCallback(

--- a/src/screens/AIChatScreen.tsx
+++ b/src/screens/AIChatScreen.tsx
@@ -34,9 +34,11 @@ import type {
   Event,
   Post,
   User,
+  Guide,
   Hashtag,
   AIPlaceRecommendation,
   AIEventRecommendation,
+  AIGuideRecommendation,
   ChatMessage,
 } from "../types";
 
@@ -284,6 +286,13 @@ export function AIChatScreen() {
           queryClient.getQueryData(["q", "trending-hashtags"]) ?? [];
         const trendingHashtags = cachedHashtags.map((h) => h.name);
 
+        const cachedGuides: Guide[] =
+          queryClient.getQueryData(["q", "guides"]) ?? [];
+        const guidesWithCreators = cachedGuides.map((g) => ({
+          ...g,
+          creatorName: profileMap.get(g.userId)?.displayName,
+        }));
+
         const aiResponse = await askAI(conversationHistory, {
           places: cachedPlaces,
           events: cachedEvents,
@@ -291,6 +300,7 @@ export function AIChatScreen() {
           followingUsers,
           userLocation,
           trendingHashtags,
+          guides: guidesWithCreators,
         });
 
         const assistantMsg: ChatMessage = {
@@ -358,6 +368,13 @@ export function AIChatScreen() {
     [router, tabPrefix]
   );
 
+  const handleGuidePress = useCallback(
+    (guideId: string) => {
+      router.push(`${tabPrefix}/guide/${guideId}`);
+    },
+    [router, tabPrefix]
+  );
+
   const handleLinkPress = useCallback(
     (url: string) => {
       const placeMatch = url.match(/^place:(.+)$/);
@@ -373,6 +390,11 @@ export function AIChatScreen() {
       const userMatch = url.match(/^user:(.+)$/);
       if (userMatch) {
         router.push(`${tabPrefix}/user/${userMatch[1]}`);
+        return false;
+      }
+      const guideMatch = url.match(/^guide:(.+)$/);
+      if (guideMatch) {
+        router.push(`${tabPrefix}/guide/${guideMatch[1]}`);
         return false;
       }
       return true;
@@ -505,6 +527,18 @@ export function AIChatScreen() {
                       key={event.eventId}
                       recommendation={event}
                       onPress={() => handleEventPress(event.eventId)}
+                    />
+                  ))}
+                </View>
+              )}
+
+              {msg.aiResponse && msg.aiResponse.guides && msg.aiResponse.guides.length > 0 && (
+                <View style={styles.cardsSection}>
+                  {msg.aiResponse.guides.map((guide) => (
+                    <GuideRecommendationCard
+                      key={guide.guideId}
+                      recommendation={guide}
+                      onPress={() => handleGuidePress(guide.guideId)}
                     />
                   ))}
                 </View>
@@ -646,6 +680,49 @@ function EventRecommendationCard({
           {recommendation.eventTitle}
         </Text>
         <Text style={styles.recCardDate}>{dateLabel}{timeLabel}</Text>
+        <Text style={styles.recCardReason} numberOfLines={2}>
+          {recommendation.reason}
+        </Text>
+      </View>
+      <SFIcon
+        name="chevron.right"
+        fallback="chevron-forward"
+        size={16}
+        color={colors.gray400}
+      />
+    </HapticPressable>
+  );
+}
+
+function GuideRecommendationCard({
+  recommendation,
+  onPress,
+}: {
+  recommendation: AIGuideRecommendation;
+  onPress: () => void;
+}) {
+  return (
+    <HapticPressable style={styles.recCard} onPress={onPress}>
+      <View
+        style={[
+          styles.recIconCircle,
+          { backgroundColor: colors.primary + "15" },
+        ]}
+      >
+        <SFIcon
+          name="book.fill"
+          fallback="book"
+          size={18}
+          color={colors.primary}
+        />
+      </View>
+      <View style={styles.recCardContent}>
+        <Text style={styles.recCardTitle} numberOfLines={1}>
+          {recommendation.guideTitle}
+        </Text>
+        <Text style={styles.recCardDate}>
+          by {recommendation.creatorName} · {recommendation.placeCount} places
+        </Text>
         <Text style={styles.recCardReason} numberOfLines={2}>
           {recommendation.reason}
         </Text>

--- a/src/screens/CreateGuideScreen.tsx
+++ b/src/screens/CreateGuideScreen.tsx
@@ -1,0 +1,576 @@
+import React, { useState, useCallback, useEffect, useMemo } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  FlatList,
+  StyleSheet,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useQueryClient } from "@tanstack/react-query";
+import { SFIcon } from "../components/SFIcon";
+import { HapticPressable } from "../components/HapticPressable";
+import { useAuth } from "../context/AuthContext";
+import { useToast } from "../context/ToastContext";
+import { useQuery } from "../hooks/useQuery";
+import {
+  getGuideById,
+  getGuidePlaces,
+  createGuide,
+  updateGuide,
+  addPlaceToGuide,
+  removePlaceFromGuide,
+} from "../services/guides";
+import { getPlacesByIds, findOrCreatePlace } from "../services/places";
+import { searchGooglePlaces } from "../services/googlePlaces";
+import { colors } from "../theme/colors";
+import { fonts } from "../theme/fonts";
+import type { Place, PlaceCategory } from "../types";
+
+const CATEGORY_ICONS: Record<PlaceCategory, { sf: string; fallback: string }> =
+  {
+    cafe: { sf: "cup.and.saucer.fill", fallback: "cafe" },
+    restaurant: { sf: "fork.knife", fallback: "restaurant" },
+    bar: { sf: "wineglass.fill", fallback: "wine" },
+    attraction: { sf: "safari", fallback: "compass" },
+    park: { sf: "leaf.fill", fallback: "leaf" },
+    venue: { sf: "music.note.list", fallback: "musical-notes" },
+    trail: { sf: "figure.hiking", fallback: "walk" },
+  };
+
+interface SelectedPlace {
+  place: Place;
+  note: string;
+}
+
+export function CreateGuideScreen() {
+  const { guideId } = useLocalSearchParams<{ guideId?: string }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const queryClient = useQueryClient();
+  const { profile } = useAuth();
+  const { showToast } = useToast();
+
+  const isEditing = !!guideId;
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [selectedPlaces, setSelectedPlaces] = useState<SelectedPlace[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<
+    { name: string; address: string; placeId?: string; category?: PlaceCategory; latitude?: number; longitude?: number }[]
+  >([]);
+  const [, setSearching] = useState(false);
+
+  // Load existing guide for editing
+  const fetchGuide = useCallback(
+    () => (guideId ? getGuideById(guideId) : Promise.resolve(null)),
+    [guideId]
+  );
+  const { data: existingGuide } = useQuery(fetchGuide, [
+    "guide",
+    guideId ?? "",
+  ]);
+
+  const fetchGuidePlaces = useCallback(
+    () => (guideId ? getGuidePlaces(guideId) : Promise.resolve([])),
+    [guideId]
+  );
+  const { data: existingGuidePlaces } = useQuery(fetchGuidePlaces, [
+    "guide-places",
+    guideId ?? "",
+  ]);
+
+  const existingPlaceIds = useMemo(
+    () => (existingGuidePlaces ?? []).map((gp) => gp.placeId),
+    [existingGuidePlaces]
+  );
+  const fetchExistingPlaces = useCallback(
+    () => getPlacesByIds(existingPlaceIds),
+    [existingPlaceIds]
+  );
+  const { data: existingPlaceData } = useQuery(fetchExistingPlaces, [
+    "places",
+    ...existingPlaceIds,
+  ]);
+
+  // Populate form when editing
+  useEffect(() => {
+    if (existingGuide && isEditing) {
+      setTitle(existingGuide.title);
+      setDescription(existingGuide.description ?? "");
+    }
+  }, [existingGuide, isEditing]);
+
+  useEffect(() => {
+    if (existingGuidePlaces && existingPlaceData && isEditing) {
+      const placeMap = new Map(existingPlaceData.map((p) => [p.id, p]));
+      const sorted = [...existingGuidePlaces].sort(
+        (a, b) => a.sortOrder - b.sortOrder
+      );
+      setSelectedPlaces(
+        sorted
+          .map((gp) => {
+            const place = placeMap.get(gp.placeId);
+            if (!place) return null;
+            return { place, note: gp.note ?? "" };
+          })
+          .filter((sp): sp is SelectedPlace => sp !== null)
+      );
+    }
+  }, [existingGuidePlaces, existingPlaceData, isEditing]);
+
+  // Search places
+  useEffect(() => {
+    if (searchQuery.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const results = await searchGooglePlaces(searchQuery);
+        setSearchResults(
+          results.map((r) => ({
+            name: r.name,
+            address: r.address,
+            placeId: r.googlePlaceId,
+            category: r.category,
+            latitude: r.latitude,
+            longitude: r.longitude,
+          }))
+        );
+      } catch {
+        setSearchResults([]);
+      } finally {
+        setSearching(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  const handleAddPlace = useCallback(
+    async (result: (typeof searchResults)[0]) => {
+      try {
+        // Find or create the place
+        const place = await findOrCreatePlace({
+          name: result.name,
+          address: result.address,
+          googlePlaceId: result.placeId,
+          category: result.category ?? "attraction",
+          latitude: result.latitude ?? -41.2865,
+          longitude: result.longitude ?? 174.7762,
+        });
+
+        // Check for duplicates
+        if (selectedPlaces.some((sp) => sp.place.id === place.id)) {
+          showToast({ message: "This place is already in the guide" });
+          return;
+        }
+
+        setSelectedPlaces((prev) => [...prev, { place, note: "" }]);
+        setSearchQuery("");
+        setSearchResults([]);
+      } catch {
+        Alert.alert("Error", "Failed to add place");
+      }
+    },
+    [selectedPlaces, showToast]
+  );
+
+  const handleRemovePlace = useCallback((index: number) => {
+    setSelectedPlaces((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleUpdateNote = useCallback((index: number, note: string) => {
+    setSelectedPlaces((prev) =>
+      prev.map((sp, i) => (i === index ? { ...sp, note } : sp))
+    );
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!profile) return;
+    if (!title.trim()) {
+      Alert.alert("Missing title", "Please enter a title for your guide");
+      return;
+    }
+    if (selectedPlaces.length === 0) {
+      Alert.alert(
+        "No places",
+        "Please add at least one place to your guide"
+      );
+      return;
+    }
+
+    setSaving(true);
+    try {
+      if (isEditing && guideId) {
+        // Update guide metadata
+        await updateGuide(guideId, {
+          title: title.trim(),
+          description: description.trim() || undefined,
+        });
+
+        // Remove all existing places and re-add
+        const existingIds = (existingGuidePlaces ?? []).map((gp) => gp.placeId);
+        for (const placeId of existingIds) {
+          await removePlaceFromGuide(guideId, placeId);
+        }
+        for (let i = 0; i < selectedPlaces.length; i++) {
+          await addPlaceToGuide(
+            guideId,
+            selectedPlaces[i].place.id,
+            i,
+            selectedPlaces[i].note || undefined
+          );
+        }
+      } else {
+        // Create new guide
+        const guide = await createGuide({
+          userId: profile.id,
+          title: title.trim(),
+          description: description.trim() || undefined,
+        });
+
+        // Add places
+        for (let i = 0; i < selectedPlaces.length; i++) {
+          await addPlaceToGuide(
+            guide.id,
+            selectedPlaces[i].place.id,
+            i,
+            selectedPlaces[i].note || undefined
+          );
+        }
+      }
+
+      queryClient.invalidateQueries({ queryKey: ["q", "guides"] });
+      queryClient.invalidateQueries({ queryKey: ["q", "guide"] });
+      showToast({ message: isEditing ? "Guide updated" : "Guide created" });
+      router.back();
+    } catch {
+      Alert.alert("Error", "Failed to save guide");
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    profile,
+    title,
+    description,
+    selectedPlaces,
+    isEditing,
+    guideId,
+    existingGuidePlaces,
+    queryClient,
+    showToast,
+    router,
+  ]);
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <View style={styles.header}>
+        <HapticPressable onPress={() => router.back()}>
+          <Text style={styles.cancelText}>Cancel</Text>
+        </HapticPressable>
+        <Text style={styles.headerTitle}>
+          {isEditing ? "Edit Guide" : "New Guide"}
+        </Text>
+        <HapticPressable onPress={handleSave} disabled={saving}>
+          <Text
+            style={[styles.saveText, saving && { opacity: 0.5 }]}
+          >
+            {saving ? "Saving..." : "Save"}
+          </Text>
+        </HapticPressable>
+      </View>
+
+      <FlatList
+        data={selectedPlaces}
+        keyExtractor={(_, index) => index.toString()}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingBottom: insets.bottom + 20,
+        }}
+        ListHeaderComponent={
+          <View style={styles.formSection}>
+            <TextInput
+              style={styles.titleInput}
+              placeholder="Guide title"
+              placeholderTextColor={colors.gray400}
+              value={title}
+              onChangeText={setTitle}
+              maxLength={100}
+            />
+            <TextInput
+              style={styles.descriptionInput}
+              placeholder="Description (optional)"
+              placeholderTextColor={colors.gray400}
+              value={description}
+              onChangeText={setDescription}
+              multiline
+              maxLength={500}
+            />
+
+            <Text style={styles.sectionTitle}>Places</Text>
+          </View>
+        }
+        renderItem={({ item, index }) => (
+          <View style={styles.selectedPlaceRow}>
+            <View style={styles.placeNumber}>
+              <Text style={styles.placeNumberText}>{index + 1}</Text>
+            </View>
+            <View
+              style={[
+                styles.placeCategoryDot,
+                {
+                  backgroundColor:
+                    colors.category[item.place.category],
+                },
+              ]}
+            >
+              <SFIcon
+                name={
+                  CATEGORY_ICONS[item.place.category].sf as any
+                }
+                fallback={
+                  CATEGORY_ICONS[item.place.category]
+                    .fallback as any
+                }
+                size={12}
+                color="#FFFFFF"
+              />
+            </View>
+            <View style={styles.selectedPlaceInfo}>
+              <Text style={styles.selectedPlaceName} numberOfLines={1}>
+                {item.place.name}
+              </Text>
+              <TextInput
+                style={styles.noteInput}
+                placeholder="Add a note..."
+                placeholderTextColor={colors.gray400}
+                value={item.note}
+                onChangeText={(text) => handleUpdateNote(index, text)}
+                maxLength={200}
+              />
+            </View>
+            <HapticPressable
+              onPress={() => handleRemovePlace(index)}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <SFIcon
+                name="xmark.circle.fill"
+                fallback="close-circle"
+                size={20}
+                color={colors.gray400}
+              />
+            </HapticPressable>
+          </View>
+        )}
+        ListFooterComponent={
+          <View style={styles.searchSection}>
+            <View style={styles.searchInputContainer}>
+              <SFIcon
+                name="magnifyingglass"
+                fallback="search"
+                size={16}
+                color={colors.gray400}
+              />
+              <TextInput
+                style={styles.searchInput}
+                placeholder="Search for a place to add..."
+                placeholderTextColor={colors.gray400}
+                value={searchQuery}
+                onChangeText={setSearchQuery}
+              />
+            </View>
+
+            {searchResults.map((result, index) => (
+              <HapticPressable
+                key={`${result.placeId ?? result.name}-${index}`}
+                style={styles.searchResultRow}
+                onPress={() => handleAddPlace(result)}
+              >
+                <SFIcon
+                  name="mappin"
+                  fallback="location"
+                  size={16}
+                  color={colors.textSecondary}
+                />
+                <View style={styles.searchResultInfo}>
+                  <Text
+                    style={styles.searchResultName}
+                    numberOfLines={1}
+                  >
+                    {result.name}
+                  </Text>
+                  <Text
+                    style={styles.searchResultAddress}
+                    numberOfLines={1}
+                  >
+                    {result.address}
+                  </Text>
+                </View>
+                <SFIcon
+                  name="plus.circle"
+                  fallback="add-circle-outline"
+                  size={20}
+                  color={colors.primary}
+                />
+              </HapticPressable>
+            ))}
+          </View>
+        }
+      />
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.gray200,
+  },
+  cancelText: {
+    fontSize: 16,
+    color: colors.textSecondary,
+    fontFamily: fonts.medium,
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontFamily: fonts.semiBold,
+    color: colors.text,
+  },
+  saveText: {
+    fontSize: 16,
+    fontFamily: fonts.semiBold,
+    color: colors.primary,
+  },
+  formSection: {
+    padding: 16,
+  },
+  titleInput: {
+    fontSize: 20,
+    fontFamily: fonts.bold,
+    color: colors.text,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.gray200,
+  },
+  descriptionInput: {
+    fontSize: 15,
+    fontFamily: fonts.medium,
+    color: colors.text,
+    paddingVertical: 12,
+    minHeight: 60,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.gray200,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontFamily: fonts.semiBold,
+    color: colors.text,
+    marginTop: 20,
+    marginBottom: 8,
+  },
+  selectedPlaceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.gray200,
+    gap: 10,
+  },
+  placeNumber: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: colors.gray100,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  placeNumberText: {
+    fontSize: 11,
+    fontFamily: fonts.semiBold,
+    color: colors.textSecondary,
+  },
+  placeCategoryDot: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  selectedPlaceInfo: {
+    flex: 1,
+  },
+  selectedPlaceName: {
+    fontSize: 14,
+    fontFamily: fonts.semiBold,
+    color: colors.text,
+  },
+  noteInput: {
+    fontSize: 13,
+    fontFamily: fonts.medium,
+    color: colors.textSecondary,
+    paddingVertical: 2,
+  },
+  searchSection: {
+    padding: 16,
+  },
+  searchInputContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: colors.gray100,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    gap: 8,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    fontFamily: fonts.medium,
+    color: colors.text,
+  },
+  searchResultRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.gray200,
+    gap: 10,
+  },
+  searchResultInfo: {
+    flex: 1,
+  },
+  searchResultName: {
+    fontSize: 14,
+    fontFamily: fonts.semiBold,
+    color: colors.text,
+  },
+  searchResultAddress: {
+    fontSize: 12,
+    color: colors.textSecondary,
+    marginTop: 1,
+  },
+});

--- a/src/screens/GuideDetailScreen.tsx
+++ b/src/screens/GuideDetailScreen.tsx
@@ -1,0 +1,456 @@
+import React, { useCallback, useMemo } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+import { Image } from "expo-image";
+import {
+  useLocalSearchParams,
+  usePathname,
+  useRouter,
+  useFocusEffect,
+} from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useHeaderHeight } from "@react-navigation/elements";
+import { SFIcon } from "../components/SFIcon";
+import { HapticPressable } from "../components/HapticPressable";
+import { LiquidGlassButton } from "../components/LiquidGlassButton";
+import { useQuery } from "../hooks/useQuery";
+import { useAuth } from "../context/AuthContext";
+import { useSave } from "../context/SaveContext";
+import { getGuideById, getGuidePlaces, deleteGuide } from "../services/guides";
+import { getPlacesByIds } from "../services/places";
+import { getProfileById } from "../services/users";
+import { shareGuide } from "../utils/sharing";
+import { colors } from "../theme/colors";
+import { fonts } from "../theme/fonts";
+import type { PlaceCategory } from "../types";
+
+const CATEGORY_ICONS: Record<PlaceCategory, { sf: string; fallback: string }> = {
+  cafe: { sf: "cup.and.saucer.fill", fallback: "cafe" },
+  restaurant: { sf: "fork.knife", fallback: "restaurant" },
+  bar: { sf: "wineglass.fill", fallback: "wine" },
+  attraction: { sf: "safari", fallback: "compass" },
+  park: { sf: "leaf.fill", fallback: "leaf" },
+  venue: { sf: "music.note.list", fallback: "musical-notes" },
+  trail: { sf: "figure.hiking", fallback: "walk" },
+};
+
+export function GuideDetailScreen() {
+  const { guideId } = useLocalSearchParams<{ guideId: string }>();
+  const router = useRouter();
+  const pathname = usePathname();
+  const tabBase = "/" + pathname.split("/")[1];
+  const insets = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
+  const { profile } = useAuth();
+  const { isSaved, toggleSave } = useSave();
+
+  const fetchGuide = useCallback(() => getGuideById(guideId), [guideId]);
+  const {
+    data: guide,
+    loading: loadingGuide,
+    refetch: refetchGuide,
+  } = useQuery(fetchGuide, ["guide", guideId]);
+
+  const fetchGuidePlaces = useCallback(
+    () => getGuidePlaces(guideId),
+    [guideId]
+  );
+  const {
+    data: guidePlaces,
+    loading: loadingPlaces,
+    refetch: refetchPlaces,
+  } = useQuery(fetchGuidePlaces, ["guide-places", guideId]);
+
+  const placeIds = useMemo(
+    () => (guidePlaces ?? []).map((gp) => gp.placeId),
+    [guidePlaces]
+  );
+  const fetchPlaces = useCallback(() => getPlacesByIds(placeIds), [placeIds]);
+  const { data: places } = useQuery(fetchPlaces, [
+    "places",
+    ...placeIds,
+  ]);
+
+  const fetchCreator = useCallback(
+    () => (guide ? getProfileById(guide.userId) : Promise.resolve(null)),
+    [guide?.userId]
+  );
+  const { data: creator } = useQuery(fetchCreator, [
+    "user",
+    guide?.userId ?? "",
+  ]);
+
+  useFocusEffect(
+    useCallback(() => {
+      refetchGuide();
+      refetchPlaces();
+    }, [refetchGuide, refetchPlaces])
+  );
+
+  const loading = loadingGuide || loadingPlaces;
+  const isOwner = profile?.id === guide?.userId;
+
+  const placeMap = useMemo(
+    () => new Map((places ?? []).map((p) => [p.id, p])),
+    [places]
+  );
+
+  const listData = useMemo(
+    () =>
+      (guidePlaces ?? []).map((gp) => ({
+        ...gp,
+        place: placeMap.get(gp.placeId),
+      })),
+    [guidePlaces, placeMap]
+  );
+
+  const handleDelete = useCallback(() => {
+    Alert.alert("Delete Guide", "Are you sure you want to delete this guide?", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await deleteGuide(guideId);
+            router.back();
+          } catch {
+            Alert.alert("Error", "Failed to delete guide");
+          }
+        },
+      },
+    ]);
+  }, [guideId, router]);
+
+  if (loading) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { justifyContent: "center", alignItems: "center" },
+        ]}
+      >
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (!guide) return null;
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={listData}
+        keyExtractor={(item) => item.placeId}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingTop: headerHeight,
+          paddingBottom: insets.bottom + 60,
+        }}
+        ListHeaderComponent={
+          <View style={styles.header}>
+            <Text style={styles.title}>{guide.title}</Text>
+            {guide.description && (
+              <Text style={styles.description}>{guide.description}</Text>
+            )}
+
+            <HapticPressable
+              style={styles.creatorRow}
+              onPress={() =>
+                router.push(`${tabBase}/user/${guide.userId}`)
+              }
+            >
+              {creator?.avatarUrl ? (
+                <Image
+                  source={{ uri: creator.avatarUrl }}
+                  style={styles.creatorAvatar}
+                  contentFit="cover"
+                  transition={200}
+                />
+              ) : (
+                <View
+                  style={[styles.creatorAvatar, styles.creatorAvatarFallback]}
+                >
+                  <SFIcon
+                    name="person.fill"
+                    fallback="person"
+                    size={14}
+                    color={colors.textMuted}
+                  />
+                </View>
+              )}
+              <Text style={styles.creatorName}>
+                {creator?.displayName ?? ""}
+              </Text>
+            </HapticPressable>
+
+            <View style={styles.statsRow}>
+              <View style={styles.stat}>
+                <SFIcon
+                  name="mappin.and.ellipse"
+                  fallback="location"
+                  size={16}
+                  color={colors.textSecondary}
+                />
+                <Text style={styles.statText}>
+                  {guide.placeCount}{" "}
+                  {guide.placeCount === 1 ? "place" : "places"}
+                </Text>
+              </View>
+              <HapticPressable
+                style={styles.stat}
+                onPress={() => toggleSave("guide", guide.id)}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <SFIcon
+                  name={
+                    isSaved("guide", guide.id)
+                      ? "bookmark.fill"
+                      : "bookmark"
+                  }
+                  fallback={
+                    isSaved("guide", guide.id)
+                      ? "bookmark"
+                      : "bookmark-outline"
+                  }
+                  size={16}
+                  color={
+                    isSaved("guide", guide.id)
+                      ? colors.saved
+                      : colors.textSecondary
+                  }
+                />
+                <Text
+                  style={[
+                    styles.statText,
+                    isSaved("guide", guide.id) && { color: colors.saved },
+                  ]}
+                >
+                  Save
+                </Text>
+              </HapticPressable>
+              <HapticPressable
+                style={styles.stat}
+                onPress={() => shareGuide(guide.id, guide.title)}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <SFIcon
+                  name="square.and.arrow.up"
+                  fallback="share-outline"
+                  size={16}
+                  color={colors.textSecondary}
+                />
+                <Text style={styles.statText}>Share</Text>
+              </HapticPressable>
+            </View>
+
+            {isOwner && (
+              <View style={styles.ownerActions}>
+                <LiquidGlassButton
+                  title="Edit Guide"
+                  variant="secondary"
+                  size="medium"
+                  icon="create-outline"
+                  onPress={() =>
+                    router.push({
+                      pathname: `${tabBase}/create-guide` as any,
+                      params: { guideId: guide.id },
+                    })
+                  }
+                  style={{ flex: 1, marginRight: 8 }}
+                />
+                <LiquidGlassButton
+                  title="Delete"
+                  variant="secondary"
+                  size="medium"
+                  icon="trash-outline"
+                  onPress={handleDelete}
+                  style={{ flex: 1 }}
+                />
+              </View>
+            )}
+          </View>
+        }
+        renderItem={({ item, index }) => {
+          const place = item.place;
+          if (!place) return null;
+
+          return (
+            <HapticPressable
+              style={styles.placeRow}
+              onPress={() =>
+                router.push(`${tabBase}/place/${place.id}`)
+              }
+            >
+              <View style={styles.placeNumber}>
+                <Text style={styles.placeNumberText}>{index + 1}</Text>
+              </View>
+              <View
+                style={[
+                  styles.placeCategoryDot,
+                  { backgroundColor: colors.category[place.category] },
+                ]}
+              >
+                <SFIcon
+                  name={CATEGORY_ICONS[place.category].sf as any}
+                  fallback={CATEGORY_ICONS[place.category].fallback as any}
+                  size={14}
+                  color="#FFFFFF"
+                />
+              </View>
+              <View style={styles.placeInfo}>
+                <Text style={styles.placeName} numberOfLines={1}>
+                  {place.name}
+                </Text>
+                <Text style={styles.placeAddress} numberOfLines={1}>
+                  {place.address}
+                </Text>
+                {item.note && (
+                  <Text style={styles.placeNote} numberOfLines={2}>
+                    {item.note}
+                  </Text>
+                )}
+              </View>
+              <SFIcon
+                name="chevron.right"
+                fallback="chevron-forward"
+                size={16}
+                color={colors.gray400}
+              />
+            </HapticPressable>
+          );
+        }}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyText}>No places in this guide yet</Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    padding: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray200,
+  },
+  title: {
+    fontSize: 24,
+    fontFamily: fonts.bold,
+    color: colors.text,
+    marginBottom: 8,
+  },
+  description: {
+    fontSize: 15,
+    color: colors.textSecondary,
+    lineHeight: 22,
+    marginBottom: 16,
+  },
+  creatorRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginBottom: 16,
+  },
+  creatorAvatar: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: colors.gray200,
+  },
+  creatorAvatarFallback: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  creatorName: {
+    fontSize: 14,
+    fontFamily: fonts.semiBold,
+    color: colors.text,
+  },
+  statsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 20,
+  },
+  stat: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+  },
+  statText: {
+    fontSize: 14,
+    color: colors.textSecondary,
+  },
+  ownerActions: {
+    flexDirection: "row",
+    marginTop: 16,
+  },
+  placeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.gray200,
+    gap: 12,
+  },
+  placeNumber: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: colors.gray100,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  placeNumberText: {
+    fontSize: 12,
+    fontFamily: fonts.semiBold,
+    color: colors.textSecondary,
+  },
+  placeCategoryDot: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  placeInfo: {
+    flex: 1,
+  },
+  placeName: {
+    fontSize: 15,
+    fontFamily: fonts.semiBold,
+    color: colors.text,
+  },
+  placeAddress: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    marginTop: 2,
+  },
+  placeNote: {
+    fontSize: 13,
+    color: colors.primary,
+    fontStyle: "italic",
+    marginTop: 4,
+  },
+  emptyState: {
+    alignItems: "center",
+    paddingVertical: 40,
+  },
+  emptyText: {
+    fontSize: 15,
+    color: colors.textMuted,
+  },
+});

--- a/src/screens/GuidesListScreen.tsx
+++ b/src/screens/GuidesListScreen.tsx
@@ -1,0 +1,152 @@
+import React, { useCallback } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  ActivityIndicator,
+} from "react-native";
+import {
+  useLocalSearchParams,
+  usePathname,
+  useRouter,
+  useFocusEffect,
+} from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useHeaderHeight } from "@react-navigation/elements";
+import { SFIcon } from "../components/SFIcon";
+import { GuideCard } from "../components/GuideCard";
+import { LiquidGlassButton } from "../components/LiquidGlassButton";
+import { useQuery } from "../hooks/useQuery";
+import { useAuth } from "../context/AuthContext";
+import { getGuidesByUserId } from "../services/guides";
+import { colors } from "../theme/colors";
+import { fonts } from "../theme/fonts";
+
+export function GuidesListScreen() {
+  const { userId } = useLocalSearchParams<{ userId: string }>();
+  const router = useRouter();
+  const pathname = usePathname();
+  const tabBase = "/" + pathname.split("/")[1];
+  const insets = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
+  const { profile } = useAuth();
+
+  const isOwnProfile = profile?.id === userId;
+
+  const fetchGuides = useCallback(
+    () => getGuidesByUserId(userId),
+    [userId]
+  );
+  const { data: guides, loading, refetch } = useQuery(fetchGuides, [
+    "guides",
+    "user",
+    userId,
+  ]);
+
+  useFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, [refetch])
+  );
+
+  if (loading) {
+    return (
+      <View
+        style={[
+          styles.container,
+          { justifyContent: "center", alignItems: "center" },
+        ]}
+      >
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={guides ?? []}
+        keyExtractor={(item) => item.id}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingTop: headerHeight + 8,
+          paddingBottom: insets.bottom + 60,
+          paddingHorizontal: 16,
+        }}
+        ListHeaderComponent={
+          isOwnProfile ? (
+            <LiquidGlassButton
+              title="Create Guide"
+              variant="primary"
+              size="medium"
+              icon="add"
+              fullWidth
+              onPress={() =>
+                router.push(`${tabBase}/create-guide` as any)
+              }
+              style={styles.createButton}
+            />
+          ) : null
+        }
+        renderItem={({ item }) => (
+          <View style={styles.cardWrapper}>
+            <GuideCard
+              guide={item}
+              onPress={() =>
+                router.push(`${tabBase}/guide/${item.id}`)
+              }
+            />
+          </View>
+        )}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <SFIcon
+              name="book"
+              fallback="book-outline"
+              size={40}
+              color={colors.gray300}
+            />
+            <Text style={styles.emptyText}>
+              {isOwnProfile
+                ? "You haven't created any guides yet"
+                : "No guides yet"}
+            </Text>
+            {isOwnProfile && (
+              <Text style={styles.emptySubtext}>
+                Create a guide to share your favourite spots
+              </Text>
+            )}
+          </View>
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  createButton: {
+    marginBottom: 16,
+  },
+  cardWrapper: {
+    marginBottom: 12,
+  },
+  emptyState: {
+    alignItems: "center",
+    paddingVertical: 60,
+    gap: 12,
+  },
+  emptyText: {
+    fontSize: 16,
+    fontFamily: fonts.semiBold,
+    color: colors.textMuted,
+  },
+  emptySubtext: {
+    fontSize: 14,
+    color: colors.textMuted,
+  },
+});

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -19,6 +19,7 @@ import { getPlaces } from "../services/places";
 import { getFollowCounts } from "../services/follows";
 import { getUnlockedAchievementCount } from "../services/achievements";
 import { getEventsByUserId } from "../services/events";
+import { getGuidesByUserId } from "../services/guides";
 import { LiquidGlassButton } from "../components/LiquidGlassButton";
 import { PostsGrid } from "../components/PostsGrid";
 import { UpcomingEvents } from "../components/UpcomingEvents";
@@ -80,6 +81,15 @@ export function ProfileScreen() {
     "user",
     currentUser.id,
   ]);
+  const fetchGuides = useCallback(
+    () => getGuidesByUserId(currentUser.id),
+    [currentUser.id]
+  );
+  const { data: guides, refetch: refetchGuides } = useQuery(fetchGuides, [
+    "guides",
+    "user",
+    currentUser.id,
+  ]);
 
   // Refetch data when screen comes into focus (e.g., after creating a new post)
   useFocusEffect(
@@ -89,12 +99,14 @@ export function ProfileScreen() {
       refetchCounts();
       refetchAchievementCount();
       refetchEvents();
+      refetchGuides();
     }, [
       refetchPosts,
       refetchPlaces,
       refetchCounts,
       refetchAchievementCount,
       refetchEvents,
+      refetchGuides,
     ])
   );
 
@@ -110,6 +122,7 @@ export function ProfileScreen() {
         refetchCounts(),
         refetchAchievementCount(),
         refetchEvents(),
+        refetchGuides(),
       ]);
     } finally {
       setRefreshing(false);
@@ -120,6 +133,7 @@ export function ProfileScreen() {
     refetchCounts,
     refetchAchievementCount,
     refetchEvents,
+    refetchGuides,
   ]);
 
   const postCount = posts?.length ?? 0;
@@ -232,6 +246,15 @@ export function ProfileScreen() {
           size="medium"
           icon="trophy"
           onPress={() => router.push("/profile/achievements")}
+          style={{ marginTop: 10 }}
+        />
+
+        <LiquidGlassButton
+          title={`Guides · ${guides?.length ?? 0}`}
+          variant="secondary"
+          size="medium"
+          icon="book-outline"
+          onPress={() => router.push({ pathname: "/profile/guides" as any, params: { userId: currentUser.id } })}
           style={{ marginTop: 10 }}
         />
 

--- a/src/screens/SavedScreen.tsx
+++ b/src/screens/SavedScreen.tsx
@@ -13,7 +13,9 @@ import { useSave } from "../context/SaveContext";
 import { getPostsByIds } from "../services/posts";
 import { getPlacesByIds } from "../services/places";
 import { getEventsByIds } from "../services/events";
+import { getGuidesByIds } from "../services/guides";
 import { getPlaces } from "../services/places";
+import { GuideCard } from "../components/GuideCard";
 import { useQuery } from "../hooks/useQuery";
 import { PostsGrid } from "../components/PostsGrid";
 import { EventCard } from "../components/EventCard";
@@ -23,7 +25,7 @@ import { colors } from "../theme/colors";
 import { fonts } from "../theme/fonts";
 import type { Place, PlaceCategory } from "../types";
 
-type Tab = "posts" | "places" | "events";
+type Tab = "posts" | "places" | "events" | "guides";
 
 const CATEGORY_ICONS: Record<PlaceCategory, { sf: string; fallback: string }> = {
   cafe: { sf: "cup.and.saucer.fill", fallback: "cafe" },
@@ -45,6 +47,7 @@ export function SavedScreen() {
   const savedPostIds = getSavedIds("post");
   const savedPlaceIds = getSavedIds("place");
   const savedEventIds = getSavedIds("event");
+  const savedGuideIds = getSavedIds("guide");
 
   const fetchPosts = useCallback(
     () => getPostsByIds(savedPostIds),
@@ -73,6 +76,15 @@ export function SavedScreen() {
     ...savedEventIds,
   ]);
 
+  const fetchGuides = useCallback(
+    () => getGuidesByIds(savedGuideIds),
+    [savedGuideIds]
+  );
+  const { data: savedGuides, refetch: refetchGuides } = useQuery(fetchGuides, [
+    "saved-guides",
+    ...savedGuideIds,
+  ]);
+
   const fetchAllPlaces = useCallback(() => getPlaces(), []);
   const { data: allPlaces } = useQuery(fetchAllPlaces, "all-places");
 
@@ -86,7 +98,8 @@ export function SavedScreen() {
       refetchPosts();
       refetchPlaces();
       refetchEvents();
-    }, [refetchPosts, refetchPlaces, refetchEvents])
+      refetchGuides();
+    }, [refetchPosts, refetchPlaces, refetchEvents, refetchGuides])
   );
 
   const postsWithPlaces = useMemo(() => {
@@ -101,6 +114,7 @@ export function SavedScreen() {
     { key: "posts", label: "Posts", count: savedPostIds.length },
     { key: "places", label: "Places", count: savedPlaceIds.length },
     { key: "events", label: "Events", count: savedEventIds.length },
+    { key: "guides", label: "Guides", count: savedGuideIds.length },
   ];
 
   const renderContent = () => {
@@ -200,6 +214,33 @@ export function SavedScreen() {
                 </View>
               );
             })}
+          </View>
+        );
+
+      case "guides":
+        if (!savedGuides || savedGuides.length === 0) {
+          return (
+            <View style={styles.emptyState}>
+              <SFIcon
+                name="bookmark"
+                fallback="bookmark-outline"
+                size={40}
+                color={colors.gray300}
+              />
+              <Text style={styles.emptyText}>No saved guides yet</Text>
+            </View>
+          );
+        }
+        return (
+          <View style={styles.guidesList}>
+            {savedGuides.map((guide) => (
+              <View key={guide.id} style={styles.guideCardWrapper}>
+                <GuideCard
+                  guide={guide}
+                  onPress={() => router.push(`/profile/guide/${guide.id}`)}
+                />
+              </View>
+            ))}
           </View>
         );
     }
@@ -354,6 +395,15 @@ const styles = StyleSheet.create({
     overflow: "hidden",
     borderWidth: 1,
     borderColor: colors.border,
+  },
+  // Guides list
+  guidesList: {
+    paddingHorizontal: 16,
+    gap: 12,
+  },
+  guideCardWrapper: {
+    borderRadius: 12,
+    overflow: "hidden",
   },
   // Empty state
   emptyState: {

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -20,9 +20,11 @@ import { getPlaces, findOrCreatePlace } from "../services/places";
 import { getPosts } from "../services/posts";
 import { getProfiles } from "../services/users";
 import { getUpcomingEvents } from "../services/events";
+import { getGuides } from "../services/guides";
 import { searchGooglePlaces } from "../services/googlePlaces";
 import { fonts } from "../theme/fonts";
 import { EventCard } from "../components/EventCard";
+import { GuideCard } from "../components/GuideCard";
 import { HapticPressable } from "../components/HapticPressable";
 import { getTrendingHashtags, searchHashtags } from "../services/hashtags";
 import { formatNumber } from "../utils/formatNumber";
@@ -31,6 +33,7 @@ import type {
   Post,
   User,
   Event,
+  Guide,
   PlaceCategory,
   Hashtag,
 } from "../types";
@@ -70,8 +73,8 @@ const ALL_CATEGORIES: PlaceCategory[] = [
 
 interface SearchResult {
   id: string;
-  type: "place" | "post" | "user" | "event" | "hashtag";
-  data: Place | Post | User | Event | Omit<Place, "id"> | Hashtag;
+  type: "place" | "post" | "user" | "event" | "hashtag" | "guide";
+  data: Place | Post | User | Event | Omit<Place, "id"> | Hashtag | Guide;
   source?: "google";
 }
 
@@ -92,6 +95,7 @@ export function SearchScreen({ query = "", onQueryChange }: SearchScreenProps) {
     getTrendingHashtags,
     "trending-hashtags"
   );
+  const { data: guides } = useQuery(getGuides, "guides");
 
   // Hashtag search state
   const [hashtagResults, setHashtagResults] = useState<Hashtag[]>([]);
@@ -278,8 +282,21 @@ export function SearchScreen({ query = "", onQueryChange }: SearchScreenProps) {
       }
     });
 
+    (guides ?? []).forEach((guide) => {
+      if (
+        guide.title.toLowerCase().includes(q) ||
+        guide.description?.toLowerCase().includes(q)
+      ) {
+        results.push({
+          id: `guide-${guide.id}`,
+          type: "guide",
+          data: guide,
+        });
+      }
+    });
+
     return results;
-  }, [query, places, posts, users, events]);
+  }, [query, places, posts, users, events, guides]);
 
   // Group search results by type, merging Google Places into the Places section
   const groupedResults = useMemo(() => {
@@ -299,6 +316,7 @@ export function SearchScreen({ query = "", onQueryChange }: SearchScreenProps) {
     const userResults = searchResults.filter((r) => r.type === "user");
     const postResults = searchResults.filter((r) => r.type === "post");
     const eventResults = searchResults.filter((r) => r.type === "event");
+    const guideResults = searchResults.filter((r) => r.type === "guide");
 
     // Deduplicate: skip Google results that already exist locally
     const localGooglePlaceIds = new Set(
@@ -326,6 +344,8 @@ export function SearchScreen({ query = "", onQueryChange }: SearchScreenProps) {
       sections.push({ title: "Posts", data: postResults.slice(0, 5) });
     if (eventResults.length > 0)
       sections.push({ title: "Events", data: eventResults });
+    if (guideResults.length > 0)
+      sections.push({ title: "Guides", data: guideResults });
 
     return sections;
   }, [searchResults, googleResults, googleLoading, hashtagResults]);
@@ -344,6 +364,10 @@ export function SearchScreen({ query = "", onQueryChange }: SearchScreenProps) {
 
   const handleEventPress = (eventId: string) => {
     router.push(`/search/event/${eventId}`);
+  };
+
+  const handleGuidePress = (guideId: string) => {
+    router.push(`/search/guide/${guideId}`);
   };
 
   const handleHashtagPress = (tagName: string) => {
@@ -525,6 +549,18 @@ export function SearchScreen({ query = "", onQueryChange }: SearchScreenProps) {
             place={place}
             onPress={() => handleEventPress(event.id)}
           />
+        );
+      }
+
+      case "guide": {
+        const guide = item.data as Guide;
+        return (
+          <View style={{ paddingHorizontal: 16, paddingVertical: 6 }}>
+            <GuideCard
+              guide={guide}
+              onPress={() => handleGuidePress(guide.id)}
+            />
+          </View>
         );
       }
 

--- a/src/screens/UserProfileScreen.tsx
+++ b/src/screens/UserProfileScreen.tsx
@@ -19,6 +19,8 @@ import { getPostsByUserId as getPostsByUserIdAsync } from "../services/posts";
 import { getPlaces } from "../services/places";
 import { getFollowCounts } from "../services/follows";
 import { getEventsByUserId } from "../services/events";
+import { getGuidesByUserId } from "../services/guides";
+import { GuideCard } from "../components/GuideCard";
 import { FollowButton } from "../components/FollowButton";
 import { PostsGrid } from "../components/PostsGrid";
 import { UpcomingEvents } from "../components/UpcomingEvents";
@@ -68,11 +70,14 @@ export function UserProfileScreen() {
   const fetchEvents = useCallback(() => getEventsByUserId(userId), [userId]);
   const { data: events, refetch: refetchEvents } = useQuery(fetchEvents, ['events', 'user', userId]);
 
+  const fetchGuides = useCallback(() => getGuidesByUserId(userId), [userId]);
+  const { data: guides, refetch: refetchGuides } = useQuery(fetchGuides, ['guides', 'user', userId]);
+
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    await Promise.all([refetchUser(), refetchPosts(), refetchPlaces(), refetchCounts(), refetchEvents()]);
+    await Promise.all([refetchUser(), refetchPosts(), refetchPlaces(), refetchCounts(), refetchEvents(), refetchGuides()]);
     setRefreshing(false);
-  }, [refetchUser, refetchPosts, refetchPlaces, refetchCounts, refetchEvents]);
+  }, [refetchUser, refetchPosts, refetchPlaces, refetchCounts, refetchEvents, refetchGuides]);
 
   // Refetch when screen comes into focus
   useFocusEffect(
@@ -185,6 +190,26 @@ export function UserProfileScreen() {
 
       <UpcomingEvents events={userEvents} />
 
+      {guides && guides.length > 0 && (
+        <View style={styles.guidesSection}>
+          <Text style={styles.guidesSectionTitle}>Guides</Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.guidesScroll}
+          >
+            {guides.map((guide) => (
+              <GuideCard
+                key={guide.id}
+                guide={guide}
+                compact
+                onPress={() => router.push(`${tabBase}/guide/${guide.id}`)}
+              />
+            ))}
+          </ScrollView>
+        </View>
+      )}
+
       <View style={styles.gridDivider} />
 
       <PostsGrid
@@ -289,9 +314,22 @@ const styles = StyleSheet.create({
   actionRow: {
     marginTop: 20,
   },
+  guidesSection: {
+    paddingTop: 16,
+  },
+  guidesSectionTitle: {
+    fontSize: 16,
+    fontFamily: fonts.semiBold,
+    color: colors.text,
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  guidesScroll: {
+    paddingHorizontal: 16,
+    gap: 12,
+  },
   gridDivider: {
     height: 1,
-    // backgroundColor: colors.gray200,
     marginTop: 8,
   },
   avatarModalBackdrop: {

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -1,4 +1,4 @@
-import type { Place, Event, Post, User, AIResponse } from '../types';
+import type { Place, Event, Post, User, Guide, AIResponse } from '../types';
 import { supabase } from '../lib/supabase';
 
 interface AIContext {
@@ -8,6 +8,7 @@ interface AIContext {
   followingUsers: User[];
   userLocation: { latitude: number; longitude: number } | null;
   trendingHashtags?: string[];
+  guides?: (Guide & { creatorName?: string })[];
 }
 
 export interface ConversationMessage {

--- a/src/services/guides.ts
+++ b/src/services/guides.ts
@@ -1,0 +1,283 @@
+import { supabase } from '../lib/supabase';
+import type { Guide, GuidePlace } from '../types';
+
+export async function getGuides(): Promise<Guide[]> {
+  const { data, error } = await supabase
+    .from('guides')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+
+  const guides = (data ?? []).map(mapGuide);
+
+  // Batch-fetch place counts
+  if (guides.length > 0) {
+    const guideIds = guides.map((g) => g.id);
+    const { data: placeRows } = await supabase
+      .from('guide_places')
+      .select('guide_id')
+      .in('guide_id', guideIds);
+
+    if (placeRows) {
+      const countMap = new Map<string, number>();
+      for (const row of placeRows) {
+        countMap.set(row.guide_id, (countMap.get(row.guide_id) ?? 0) + 1);
+      }
+      for (const guide of guides) {
+        guide.placeCount = countMap.get(guide.id) ?? 0;
+      }
+    }
+  }
+
+  return guides;
+}
+
+export async function getGuidesByUserId(userId: string): Promise<Guide[]> {
+  const { data, error } = await supabase
+    .from('guides')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+
+  const guides = (data ?? []).map(mapGuide);
+
+  // Batch-fetch place counts
+  if (guides.length > 0) {
+    const guideIds = guides.map((g) => g.id);
+    const { data: placeRows } = await supabase
+      .from('guide_places')
+      .select('guide_id')
+      .in('guide_id', guideIds);
+
+    if (placeRows) {
+      const countMap = new Map<string, number>();
+      for (const row of placeRows) {
+        countMap.set(row.guide_id, (countMap.get(row.guide_id) ?? 0) + 1);
+      }
+      for (const guide of guides) {
+        guide.placeCount = countMap.get(guide.id) ?? 0;
+      }
+    }
+  }
+
+  return guides;
+}
+
+export async function getGuideById(guideId: string): Promise<Guide | null> {
+  const { data, error } = await supabase
+    .from('guides')
+    .select('*')
+    .eq('id', guideId)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return null;
+    throw error;
+  }
+
+  const guide = mapGuide(data);
+
+  // Get place count
+  const { count } = await supabase
+    .from('guide_places')
+    .select('*', { count: 'exact', head: true })
+    .eq('guide_id', guideId);
+
+  guide.placeCount = count ?? 0;
+
+  return guide;
+}
+
+export async function getGuidePlaces(guideId: string): Promise<GuidePlace[]> {
+  const { data, error } = await supabase
+    .from('guide_places')
+    .select('*')
+    .eq('guide_id', guideId)
+    .order('sort_order', { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []).map(mapGuidePlace);
+}
+
+export async function getGuidesByIds(ids: string[]): Promise<Guide[]> {
+  if (ids.length === 0) return [];
+
+  const { data, error } = await supabase
+    .from('guides')
+    .select('*')
+    .in('id', ids);
+
+  if (error) throw error;
+
+  const guides = (data ?? []).map(mapGuide);
+
+  // Batch-fetch place counts
+  if (guides.length > 0) {
+    const guideIds = guides.map((g) => g.id);
+    const { data: placeRows } = await supabase
+      .from('guide_places')
+      .select('guide_id')
+      .in('guide_id', guideIds);
+
+    if (placeRows) {
+      const countMap = new Map<string, number>();
+      for (const row of placeRows) {
+        countMap.set(row.guide_id, (countMap.get(row.guide_id) ?? 0) + 1);
+      }
+      for (const guide of guides) {
+        guide.placeCount = countMap.get(guide.id) ?? 0;
+      }
+    }
+  }
+
+  return guides;
+}
+
+export async function createGuide(params: {
+  userId: string;
+  title: string;
+  description?: string;
+  coverImageUrl?: string;
+}): Promise<Guide> {
+  const { data, error } = await supabase
+    .from('guides')
+    .insert({
+      user_id: params.userId,
+      title: params.title,
+      description: params.description ?? null,
+      cover_image_url: params.coverImageUrl ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return { ...mapGuide(data), placeCount: 0 };
+}
+
+export async function updateGuide(
+  guideId: string,
+  params: {
+    title?: string;
+    description?: string;
+    coverImageUrl?: string;
+  }
+): Promise<void> {
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (params.title !== undefined) updates.title = params.title;
+  if (params.description !== undefined) updates.description = params.description;
+  if (params.coverImageUrl !== undefined) updates.cover_image_url = params.coverImageUrl;
+
+  const { error } = await supabase
+    .from('guides')
+    .update(updates)
+    .eq('id', guideId);
+
+  if (error) throw error;
+}
+
+export async function deleteGuide(guideId: string): Promise<void> {
+  const { error } = await supabase
+    .from('guides')
+    .delete()
+    .eq('id', guideId);
+
+  if (error) throw error;
+}
+
+export async function addPlaceToGuide(
+  guideId: string,
+  placeId: string,
+  sortOrder: number,
+  note?: string
+): Promise<void> {
+  const { error } = await supabase
+    .from('guide_places')
+    .insert({
+      guide_id: guideId,
+      place_id: placeId,
+      sort_order: sortOrder,
+      note: note ?? null,
+    });
+
+  if (error) throw error;
+
+  // Touch guide updated_at
+  await supabase
+    .from('guides')
+    .update({ updated_at: new Date().toISOString() })
+    .eq('id', guideId);
+}
+
+export async function removePlaceFromGuide(guideId: string, placeId: string): Promise<void> {
+  const { error } = await supabase
+    .from('guide_places')
+    .delete()
+    .eq('guide_id', guideId)
+    .eq('place_id', placeId);
+
+  if (error) throw error;
+
+  // Touch guide updated_at
+  await supabase
+    .from('guides')
+    .update({ updated_at: new Date().toISOString() })
+    .eq('id', guideId);
+}
+
+export async function updateGuidePlace(
+  guideId: string,
+  placeId: string,
+  params: { sortOrder?: number; note?: string }
+): Promise<void> {
+  const updates: Record<string, unknown> = {};
+  if (params.sortOrder !== undefined) updates.sort_order = params.sortOrder;
+  if (params.note !== undefined) updates.note = params.note;
+
+  const { error } = await supabase
+    .from('guide_places')
+    .update(updates)
+    .eq('guide_id', guideId)
+    .eq('place_id', placeId);
+
+  if (error) throw error;
+}
+
+function mapGuide(row: {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string | null;
+  cover_image_url: string | null;
+  created_at: string;
+  updated_at: string;
+}): Guide {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    title: row.title,
+    description: row.description ?? undefined,
+    coverImageUrl: row.cover_image_url ?? undefined,
+    placeCount: 0,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapGuidePlace(row: {
+  guide_id: string;
+  place_id: string;
+  sort_order: number;
+  note: string | null;
+  added_at: string;
+}): GuidePlace {
+  return {
+    guideId: row.guide_id,
+    placeId: row.place_id,
+    sortOrder: row.sort_order,
+    note: row.note ?? undefined,
+    addedAt: row.added_at,
+  };
+}

--- a/src/services/saves.ts
+++ b/src/services/saves.ts
@@ -3,7 +3,7 @@ import type { SavedItemType } from '../types/database';
 
 export async function getSavedItemIds(
   userId: string
-): Promise<{ posts: string[]; places: string[]; events: string[] }> {
+): Promise<{ posts: string[]; places: string[]; events: string[]; guides: string[] }> {
   const { data, error } = await supabase
     .from('saved_items')
     .select('item_type, item_id')
@@ -11,11 +11,12 @@ export async function getSavedItemIds(
 
   if (error) throw error;
 
-  const result = { posts: [] as string[], places: [] as string[], events: [] as string[] };
+  const result = { posts: [] as string[], places: [] as string[], events: [] as string[], guides: [] as string[] };
   for (const row of data ?? []) {
     if (row.item_type === 'post') result.posts.push(row.item_id);
     else if (row.item_type === 'place') result.places.push(row.item_id);
     else if (row.item_type === 'event') result.events.push(row.item_id);
+    else if (row.item_type === 'guide') result.guides.push(row.item_id);
   }
   return result;
 }

--- a/src/types/AI.ts
+++ b/src/types/AI.ts
@@ -13,10 +13,19 @@ export interface AIEventRecommendation {
   reason: string;
 }
 
+export interface AIGuideRecommendation {
+  guideId: string;
+  guideTitle: string;
+  creatorName: string;
+  placeCount: number;
+  reason: string;
+}
+
 export interface AIResponse {
   message: string;
   places: AIPlaceRecommendation[];
   events: AIEventRecommendation[];
+  guides: AIGuideRecommendation[];
 }
 
 export interface ChatMessage {

--- a/src/types/Guide.ts
+++ b/src/types/Guide.ts
@@ -1,0 +1,18 @@
+export interface Guide {
+  id: string;
+  userId: string;
+  title: string;
+  description?: string;
+  coverImageUrl?: string;
+  placeCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GuidePlace {
+  guideId: string;
+  placeId: string;
+  sortOrder: number;
+  note?: string;
+  addedAt: string;
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -643,6 +643,77 @@ export type Database = {
           },
         ];
       };
+      guides: {
+        Row: {
+          id: string;
+          user_id: string;
+          title: string;
+          description: string | null;
+          cover_image_url: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          title: string;
+          description?: string | null;
+          cover_image_url?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          title?: string;
+          description?: string | null;
+          cover_image_url?: string | null;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'guides_user_id_fkey';
+            columns: ['user_id'];
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+            isOneToOne: false;
+          },
+        ];
+      };
+      guide_places: {
+        Row: {
+          guide_id: string;
+          place_id: string;
+          sort_order: number;
+          note: string | null;
+          added_at: string;
+        };
+        Insert: {
+          guide_id: string;
+          place_id: string;
+          sort_order: number;
+          note?: string | null;
+          added_at?: string;
+        };
+        Update: {
+          sort_order?: number;
+          note?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'guide_places_guide_id_fkey';
+            columns: ['guide_id'];
+            referencedRelation: 'guides';
+            referencedColumns: ['id'];
+            isOneToOne: false;
+          },
+          {
+            foreignKeyName: 'guide_places_place_id_fkey';
+            columns: ['place_id'];
+            referencedRelation: 'places';
+            referencedColumns: ['id'];
+            isOneToOne: false;
+          },
+        ];
+      };
     };
     Views: {};
     Functions: {};
@@ -665,7 +736,7 @@ export type TrailDifficulty = 'easy' | 'moderate' | 'hard';
 export type ExplorationMethod = 'viewed' | 'posted';
 export type AchievementType = 'category' | 'milestone' | 'neighborhood' | 'social';
 export type NotificationType = 'like' | 'comment' | 'follow';
-export type SavedItemType = 'post' | 'place' | 'event';
+export type SavedItemType = 'post' | 'place' | 'event' | 'guide';
 
 export type Tables<T extends keyof Database['public']['Tables']> =
   Database['public']['Tables'][T]['Row'];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './Exploration';
 export * from './Trail';
 export * from './AI';
 export * from './Hashtag';
+export * from './Guide';

--- a/src/utils/sharing.ts
+++ b/src/utils/sharing.ts
@@ -20,6 +20,10 @@ export function getUserUrl(userId: string): string {
   return `${WEBSITE_URL}/user/${userId}`;
 }
 
+export function getGuideUrl(guideId: string): string {
+  return `${WEBSITE_URL}/guide/${guideId}`;
+}
+
 // Share helpers
 export function sharePost(
   postId: string,
@@ -42,5 +46,12 @@ export function shareEvent(
   const url = getEventUrl(eventId);
   Share.share({
     message: `${title} — ${date} at ${placeName}\n${description}\n${url}`,
+  });
+}
+
+export function shareGuide(guideId: string, title: string): void {
+  const url = getGuideUrl(guideId);
+  Share.share({
+    message: `Check out this guide: ${title}\n${url}`,
   });
 }

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -35,6 +35,13 @@ interface FollowingUser {
   displayName?: string;
 }
 
+interface Guide {
+  id: string;
+  title: string;
+  placeCount: number;
+  creatorName?: string;
+}
+
 interface AIContext {
   places: Place[];
   events: Event[];
@@ -42,6 +49,7 @@ interface AIContext {
   followingUsers: FollowingUser[];
   userLocation: { latitude: number; longitude: number } | null;
   trendingHashtags?: string[];
+  guides?: Guide[];
 }
 
 interface ConversationMessage {
@@ -53,6 +61,7 @@ interface AIResponse {
   message: string;
   places: { placeId: string; placeName: string; category: string; reason: string }[];
   events: { eventId: string; eventTitle: string; date: string; startTime?: string; reason: string }[];
+  guides: { guideId: string; guideTitle: string; creatorName: string; placeCount: number; reason: string }[];
 }
 
 const WEATHER_CODES: Record<number, string> = {
@@ -177,6 +186,9 @@ ${followingStr || "Not following anyone yet."}
 RECENT POSTS FROM FOLLOWED USERS (user|place|content):
 ${postsStr || "No recent posts."}
 
+GUIDES (id|title|creator|placeCount):
+${ctx.guides?.length ? ctx.guides.map((g) => `${g.id}|${g.title}|${g.creatorName ?? "unknown"}|${g.placeCount} places`).join("\n") : "No guides yet."}
+
 TRENDING HASHTAGS:
 ${ctx.trendingHashtags?.length ? ctx.trendingHashtags.map((t) => `#${t}`).join(", ") : "None yet."}
 
@@ -196,25 +208,37 @@ INSTRUCTIONS:
 {
   "message": "Your friendly response text here",
   "places": [{"placeId": "uuid", "placeName": "Name", "category": "cafe", "reason": "Short reason"}],
-  "events": [{"eventId": "uuid", "eventTitle": "Title", "date": "2026-02-20", "startTime": "18:00", "reason": "Short reason"}]
+  "events": [{"eventId": "uuid", "eventTitle": "Title", "date": "2026-02-20", "startTime": "18:00", "reason": "Short reason"}],
+  "guides": [{"guideId": "uuid", "guideTitle": "Title", "creatorName": "Name", "placeCount": 5, "reason": "Short reason"}]
 }
-- Only include places/events that exist in the data above
-- Include 1-4 places and 0-3 events as relevant to the question
+- Only include places/events/guides that exist in the data above
+- Include 1-4 places, 0-3 events, and 0-2 guides as relevant to the question
+- When users ask for curated lists, recommendations from locals, or "best of" type questions, consider suggesting relevant guides
+- When mentioning guides in message text, use: [Guide Title](guide:guideId)
 - When suggesting activities, you may reference relevant trending hashtags to help users discover related content
 - If the question is unrelated to Wellington activities, respond helpfully but keep places/events arrays empty`;
+}
+
+function normalizeResponse(parsed: Record<string, unknown>): AIResponse {
+  return {
+    message: String(parsed.message ?? ""),
+    places: Array.isArray(parsed.places) ? parsed.places : [],
+    events: Array.isArray(parsed.events) ? parsed.events : [],
+    guides: Array.isArray(parsed.guides) ? parsed.guides : [],
+  };
 }
 
 function parseAIResponse(text: string): AIResponse {
   try {
     const parsed = JSON.parse(text);
-    if (parsed.message) return parsed;
+    if (parsed.message) return normalizeResponse(parsed);
   } catch { /* continue */ }
 
   const codeBlockMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
   if (codeBlockMatch) {
     try {
       const parsed = JSON.parse(codeBlockMatch[1]);
-      if (parsed.message) return parsed;
+      if (parsed.message) return normalizeResponse(parsed);
     } catch { /* continue */ }
   }
 
@@ -222,7 +246,7 @@ function parseAIResponse(text: string): AIResponse {
   if (jsonMatch) {
     try {
       const parsed = JSON.parse(jsonMatch[0]);
-      if (parsed.message) return parsed;
+      if (parsed.message) return normalizeResponse(parsed);
     } catch { /* continue */ }
   }
 
@@ -230,6 +254,7 @@ function parseAIResponse(text: string): AIResponse {
     message: text,
     places: [],
     events: [],
+    guides: [],
   };
 }
 

--- a/supabase/migrations/20260222200000_add_guides.sql
+++ b/supabase/migrations/20260222200000_add_guides.sql
@@ -1,0 +1,66 @@
+-- Guides: curated lists of places created by users
+create table guides (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references profiles(id) on delete cascade,
+  title text not null,
+  description text,
+  cover_image_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index guides_user_id_idx on guides(user_id);
+create index guides_created_at_idx on guides(created_at desc);
+
+-- Guide places (join table)
+create table guide_places (
+  guide_id uuid not null references guides(id) on delete cascade,
+  place_id uuid not null references places(id) on delete cascade,
+  sort_order integer not null default 0,
+  note text,
+  added_at timestamptz not null default now(),
+  primary key (guide_id, place_id)
+);
+
+create index guide_places_guide_id_idx on guide_places(guide_id);
+
+-- RLS: guides
+alter table guides enable row level security;
+
+create policy "Guides are viewable by everyone"
+  on guides for select using (true);
+
+create policy "Users can create own guides"
+  on guides for insert with check (auth.uid() = user_id);
+
+create policy "Users can update own guides"
+  on guides for update using (auth.uid() = user_id);
+
+create policy "Users can delete own guides"
+  on guides for delete using (auth.uid() = user_id);
+
+-- RLS: guide_places
+alter table guide_places enable row level security;
+
+create policy "Guide places are viewable by everyone"
+  on guide_places for select using (true);
+
+create policy "Guide owner can add places"
+  on guide_places for insert with check (
+    exists (select 1 from guides where guides.id = guide_id and guides.user_id = auth.uid())
+  );
+
+create policy "Guide owner can update places"
+  on guide_places for update using (
+    exists (select 1 from guides where guides.id = guide_id and guides.user_id = auth.uid())
+  );
+
+create policy "Guide owner can remove places"
+  on guide_places for delete using (
+    exists (select 1 from guides where guides.id = guide_id and guides.user_id = auth.uid())
+  );
+
+-- Extend saved_items to allow 'guide' type
+alter table saved_items drop constraint if exists saved_items_item_type_check;
+alter table saved_items add constraint saved_items_item_type_check
+  check (item_type in ('post', 'place', 'event', 'guide'));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -446,7 +446,7 @@ create policy "trails_public_read" on trails
 -- Saved/bookmarked items (posts, places, events)
 create table if not exists saved_items (
   user_id uuid not null references profiles(id) on delete cascade,
-  item_type text not null check (item_type in ('post', 'place', 'event')),
+  item_type text not null check (item_type in ('post', 'place', 'event', 'guide')),
   item_id uuid not null,
   created_at timestamptz not null default now(),
   primary key (user_id, item_type, item_id)
@@ -468,6 +468,68 @@ create policy "Users can save items"
 drop policy if exists "Users can unsave items" on saved_items;
 create policy "Users can unsave items"
   on saved_items for delete using (auth.uid() = user_id);
+
+-- Guides: curated lists of places created by users
+create table guides (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references profiles(id) on delete cascade,
+  title text not null,
+  description text,
+  cover_image_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index guides_user_id_idx on guides(user_id);
+create index guides_created_at_idx on guides(created_at desc);
+
+-- Guide places (join table)
+create table guide_places (
+  guide_id uuid not null references guides(id) on delete cascade,
+  place_id uuid not null references places(id) on delete cascade,
+  sort_order integer not null default 0,
+  note text,
+  added_at timestamptz not null default now(),
+  primary key (guide_id, place_id)
+);
+
+create index guide_places_guide_id_idx on guide_places(guide_id);
+
+-- RLS: guides
+alter table guides enable row level security;
+
+create policy "Guides are viewable by everyone"
+  on guides for select using (true);
+
+create policy "Users can create own guides"
+  on guides for insert with check (auth.uid() = user_id);
+
+create policy "Users can update own guides"
+  on guides for update using (auth.uid() = user_id);
+
+create policy "Users can delete own guides"
+  on guides for delete using (auth.uid() = user_id);
+
+-- RLS: guide_places
+alter table guide_places enable row level security;
+
+create policy "Guide places are viewable by everyone"
+  on guide_places for select using (true);
+
+create policy "Guide owner can add places"
+  on guide_places for insert with check (
+    exists (select 1 from guides where guides.id = guide_id and guides.user_id = auth.uid())
+  );
+
+create policy "Guide owner can update places"
+  on guide_places for update using (
+    exists (select 1 from guides where guides.id = guide_id and guides.user_id = auth.uid())
+  );
+
+create policy "Guide owner can remove places"
+  on guide_places for delete using (
+    exists (select 1 from guides where guides.id = guide_id and guides.user_id = auth.uid())
+  );
 
 -- Instagram connections for importing posts
 create table if not exists instagram_connections (

--- a/supabase/seed-guides.sql
+++ b/supabase/seed-guides.sql
@@ -1,0 +1,49 @@
+-- Seed guides data (run after migration 20260222200000_add_guides.sql)
+
+insert into guides (id, user_id, title, description) values
+  ('60000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002',
+   'Best Brunch Spots in Wellington',
+   'My favourite places for a lazy weekend brunch. These cafes never disappoint!'),
+  ('60000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000005',
+   'Wellington Coffee Trail',
+   'The definitive guide to specialty coffee in Wellington. Work your way through these and thank me later.'),
+  ('60000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000007',
+   'Craft Beer Crawl',
+   'The ultimate Wellington craft beer crawl. Start early, pace yourself, and enjoy the best brews in town.'),
+  ('60000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000002',
+   'Date Night Spots',
+   'Impress your date with these Wellington gems. From cosy bars to fine dining.'),
+  ('60000000-0000-0000-0000-000000000005', '00000000-0000-0000-0000-000000000006',
+   'Best Views in Wellington',
+   'Wellington has incredible viewpoints. Here are the best spots to take it all in.')
+on conflict (id) do nothing;
+
+insert into guide_places (guide_id, place_id, sort_order, note) values
+  -- Best Brunch Spots (sarah_eats_welly)
+  ('60000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000003', 0, 'The ricotta hotcakes are legendary'),
+  ('60000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000005', 1, 'Great cabinet food and excellent coffee'),
+  ('60000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000004', 2, 'Hidden gem in Thorndon with amazing seasonal menu'),
+  ('60000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000028', 3, 'Classic Wellington vibes'),
+  -- Wellington Coffee Trail (coffeesnob_nz)
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000001', 0, 'Best flat white in the city, hands down'),
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000002', 1, 'The OG specialty coffee spot'),
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000023', 2, 'Ethical and delicious — try the cold brew'),
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000024', 3, 'Beautiful space, incredible pour-over'),
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000025', 4, 'Great beans from Raglan, solid espresso'),
+  -- Craft Beer Crawl (craft_beer_sam)
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000039', 0, 'Start here — always rotating taps of the freshest brews'),
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000010', 1, 'Dive bar vibes with excellent NZ craft selection'),
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000009', 2, 'Japanese beer imports you won''t find anywhere else'),
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000037', 3, 'Good food to soak it up and solid tap list'),
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000012', 4, 'End here — great beer garden if the weather''s good'),
+  -- Date Night Spots (sarah_eats_welly)
+  ('60000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000035', 0, 'Start with cocktails — the atmosphere is unreal'),
+  ('60000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000029', 1, 'Classic fine dining, never disappoints'),
+  ('60000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000011', 2, 'Secret bar for after-dinner drinks'),
+  ('60000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000006', 3, 'For a truly special occasion — indigenous NZ cuisine'),
+  -- Best Views (welly_walks)
+  ('60000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000017', 0, 'The classic Wellington panorama'),
+  ('60000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000014', 1, 'Ride the cable car up for great harbour views'),
+  ('60000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000016', 2, 'Wander through the gardens and enjoy the city below'),
+  ('60000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000018', 3, 'Sunset from Oriental Bay is magical')
+on conflict (guide_id, place_id) do nothing;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -793,3 +793,60 @@ INSERT INTO post_hashtags (post_id, hashtag_id) VALUES
   ('20000000-0000-0000-0000-000000000019', '50000000-0000-0000-0000-000000000016'), -- #nature
   -- Customs (u5)
   ('20000000-0000-0000-0000-000000000031', '50000000-0000-0000-0000-000000000001'); -- #coffee
+
+-- ============================================================
+-- GUIDES
+-- ============================================================
+
+-- Guide UUIDs:
+-- g1: 60000000-0000-0000-0000-000000000001  (sarah_eats_welly - Best Brunch Spots)
+-- g2: 60000000-0000-0000-0000-000000000002  (coffeesnob_nz - Wellington Coffee Trail)
+-- g3: 60000000-0000-0000-0000-000000000003  (craft_beer_sam - Craft Beer Crawl)
+-- g4: 60000000-0000-0000-0000-000000000004  (sarah_eats_welly - Date Night Spots)
+-- g5: 60000000-0000-0000-0000-000000000005  (welly_walks - Best Views in Wellington)
+
+insert into guides (id, user_id, title, description) values
+  ('60000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002',
+   'Best Brunch Spots in Wellington',
+   'My favourite places for a lazy weekend brunch. These cafes never disappoint!'),
+  ('60000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000005',
+   'Wellington Coffee Trail',
+   'The definitive guide to specialty coffee in Wellington. Work your way through these and thank me later.'),
+  ('60000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000007',
+   'Craft Beer Crawl',
+   'The ultimate Wellington craft beer crawl. Start early, pace yourself, and enjoy the best brews in town.'),
+  ('60000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000002',
+   'Date Night Spots',
+   'Impress your date with these Wellington gems. From cosy bars to fine dining.'),
+  ('60000000-0000-0000-0000-000000000005', '00000000-0000-0000-0000-000000000006',
+   'Best Views in Wellington',
+   'Wellington has incredible viewpoints. Here are the best spots to take it all in.');
+
+insert into guide_places (guide_id, place_id, sort_order, note) values
+  -- Best Brunch Spots (sarah_eats_welly)
+  ('60000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000003', 0, 'The ricotta hotcakes are legendary'),
+  ('60000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000005', 1, 'Great cabinet food and excellent coffee'),
+  ('60000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000004', 2, 'Hidden gem in Thorndon with amazing seasonal menu'),
+  ('60000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000028', 3, 'Classic Wellington vibes'),
+  -- Wellington Coffee Trail (coffeesnob_nz)
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000001', 0, 'Best flat white in the city, hands down'),
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000002', 1, 'The OG specialty coffee spot'),
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000023', 2, 'Ethical and delicious — try the cold brew'),
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000024', 3, 'Beautiful space, incredible pour-over'),
+  ('60000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000025', 4, 'Great beans from Raglan, solid espresso'),
+  -- Craft Beer Crawl (craft_beer_sam)
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000039', 0, 'Start here — always rotating taps of the freshest brews'),
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000010', 1, 'Dive bar vibes with excellent NZ craft selection'),
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000009', 2, 'Japanese beer imports you won''t find anywhere else'),
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000037', 3, 'Good food to soak it up and solid tap list'),
+  ('60000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000012', 4, 'End here — great beer garden if the weather''s good'),
+  -- Date Night Spots (sarah_eats_welly)
+  ('60000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000035', 0, 'Start with cocktails — the atmosphere is unreal'),
+  ('60000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000029', 1, 'Classic fine dining, never disappoints'),
+  ('60000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000011', 2, 'Secret bar for after-dinner drinks'),
+  ('60000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000006', 3, 'For a truly special occasion — indigenous NZ cuisine'),
+  -- Best Views (welly_walks)
+  ('60000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000017', 0, 'The classic Wellington panorama'),
+  ('60000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000014', 1, 'Ride the cable car up for great harbour views'),
+  ('60000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000016', 2, 'Wander through the gardens and enjoy the city below'),
+  ('60000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000018', 3, 'Sunset from Oriental Bay is magical');


### PR DESCRIPTION
## Summary

- Adds the full **Guides** feature — curated lists of places created by users (influencers, food bloggers, etc.)
- Database: `guides` and `guide_places` tables with RLS policies, migration, and seed data (5 sample guides with 22 places)
- Types, service layer (`guides.ts`), and `GuideCard` component
- Three new screens: `GuideDetailScreen`, `GuidesListScreen`, `CreateGuideScreen` (create + edit)
- Routes registered in all 5 tabs (profile, map, feed, search, events)
- Integrated into profiles (own + other users), saved items, search results, and AI chat
- Sharing support with `getGuideUrl()` and `shareGuide()`
- Related: GitHub issue #61 created for future Google Maps list import

## Test plan

- [ ] Create a new guide with title, description, and places via the Create Guide screen
- [ ] Edit an existing guide (change title, add/remove places)
- [ ] View guides on own profile and other users' profiles
- [ ] Navigate to guide detail from all tabs (map, feed, search, events, profile)
- [ ] Save/unsave a guide and verify it appears in the Saved > Guides tab
- [ ] Search for guides by title in the Search screen
- [ ] Ask the AI chat about guides and verify guide recommendations appear
- [ ] Share a guide and verify the share URL is correct
- [ ] Delete a guide from the detail screen (owner only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)