### PR TITLE
Improve guides: AI chat integration + visual media from posts

### DIFF
--- a/src/components/GuideCard.tsx
+++ b/src/components/GuideCard.tsx
@@ -28,10 +28,10 @@ export function GuideCard({ guide, onPress, compact }: GuideCardProps) {
       style={[styles.container, compact && styles.containerCompact]}
       onPress={onPress}
     >
-      {guide.coverImageUrl ? (
+      {(guide.coverImageUrl || guide.firstPlaceImageUrl) ? (
         <View style={[styles.imageContainer, compact && styles.imageContainerCompact]}>
           <Image
-            source={{ uri: guide.coverImageUrl }}
+            source={{ uri: guide.coverImageUrl ?? guide.firstPlaceImageUrl }}
             style={styles.image}
             contentFit="cover"
             transition={200}

--- a/src/screens/AIChatScreen.tsx
+++ b/src/screens/AIChatScreen.tsx
@@ -24,6 +24,7 @@ import { useAuth } from "../context/AuthContext";
 import { useFollow } from "../context/FollowContext";
 import { useLocation } from "../context/LocationContext";
 import { askAI } from "../services/ai";
+import { getGuidesWithPlaces } from "../services/guides";
 import { SFIcon } from "../components/SFIcon";
 import { HapticPressable } from "../components/HapticPressable";
 import Markdown from "react-native-markdown-display";
@@ -34,7 +35,6 @@ import type {
   Event,
   Post,
   User,
-  Guide,
   Hashtag,
   AIPlaceRecommendation,
   AIEventRecommendation,
@@ -286,12 +286,7 @@ export function AIChatScreen() {
           queryClient.getQueryData(["q", "trending-hashtags"]) ?? [];
         const trendingHashtags = cachedHashtags.map((h) => h.name);
 
-        const cachedGuides: Guide[] =
-          queryClient.getQueryData(["q", "guides"]) ?? [];
-        const guidesWithCreators = cachedGuides.map((g) => ({
-          ...g,
-          creatorName: profileMap.get(g.userId)?.displayName,
-        }));
+        const guides = await getGuidesWithPlaces();
 
         const aiResponse = await askAI(conversationHistory, {
           places: cachedPlaces,
@@ -300,7 +295,7 @@ export function AIChatScreen() {
           followingUsers,
           userLocation,
           trendingHashtags,
-          guides: guidesWithCreators,
+          guides,
         });
 
         const assistantMsg: ChatMessage = {

--- a/src/screens/GuideDetailScreen.tsx
+++ b/src/screens/GuideDetailScreen.tsx
@@ -19,11 +19,13 @@ import { useHeaderHeight } from "@react-navigation/elements";
 import { SFIcon } from "../components/SFIcon";
 import { HapticPressable } from "../components/HapticPressable";
 import { LiquidGlassButton } from "../components/LiquidGlassButton";
+import { LinearGradient } from "expo-linear-gradient";
 import { useQuery } from "../hooks/useQuery";
 import { useAuth } from "../context/AuthContext";
 import { useSave } from "../context/SaveContext";
 import { getGuideById, getGuidePlaces, deleteGuide } from "../services/guides";
 import { getPlacesByIds } from "../services/places";
+import { getTopPostMediaForPlaces } from "../services/posts";
 import { getProfileById } from "../services/users";
 import { shareGuide } from "../utils/sharing";
 import { colors } from "../theme/colors";
@@ -77,6 +79,15 @@ export function GuideDetailScreen() {
     ...placeIds,
   ]);
 
+  const fetchMedia = useCallback(
+    () => getTopPostMediaForPlaces(placeIds),
+    [placeIds]
+  );
+  const { data: placeMediaMap } = useQuery(fetchMedia, [
+    "place-media",
+    ...placeIds,
+  ]);
+
   const fetchCreator = useCallback(
     () => (guide ? getProfileById(guide.userId) : Promise.resolve(null)),
     [guide?.userId]
@@ -101,13 +112,24 @@ export function GuideDetailScreen() {
     [places]
   );
 
+  const heroImageUrl = useMemo(() => {
+    if (guide?.coverImageUrl) return guide.coverImageUrl;
+    const firstPlaceId = guidePlaces?.[0]?.placeId;
+    if (firstPlaceId && placeMediaMap) {
+      const media = placeMediaMap.get(firstPlaceId);
+      return media?.thumbnailUrl ?? media?.mediaUrl;
+    }
+    return undefined;
+  }, [guide?.coverImageUrl, guidePlaces, placeMediaMap]);
+
   const listData = useMemo(
     () =>
       (guidePlaces ?? []).map((gp) => ({
         ...gp,
         place: placeMap.get(gp.placeId),
+        imageUrl: placeMediaMap?.get(gp.placeId),
       })),
-    [guidePlaces, placeMap]
+    [guidePlaces, placeMap, placeMediaMap]
   );
 
   const handleDelete = useCallback(() => {
@@ -154,6 +176,23 @@ export function GuideDetailScreen() {
           paddingBottom: insets.bottom + 60,
         }}
         ListHeaderComponent={
+          <>
+            {heroImageUrl && (
+              <View style={styles.heroContainer}>
+                <Image
+                  source={{ uri: heroImageUrl }}
+                  style={styles.heroImage}
+                  contentFit="cover"
+                  transition={200}
+                />
+                <LinearGradient
+                  colors={["transparent", "rgba(0,0,0,0.6)"]}
+                  start={{ x: 0, y: 0.4 }}
+                  end={{ x: 0, y: 1 }}
+                  style={styles.heroGradient}
+                />
+              </View>
+            )}
           <View style={styles.header}>
             <Text style={styles.title}>{guide.title}</Text>
             {guide.description && (
@@ -276,10 +315,12 @@ export function GuideDetailScreen() {
               </View>
             )}
           </View>
+          </>
         }
         renderItem={({ item, index }) => {
           const place = item.place;
           if (!place) return null;
+          const mediaUrl = item.imageUrl?.thumbnailUrl ?? item.imageUrl?.mediaUrl;
 
           return (
             <HapticPressable
@@ -291,19 +332,28 @@ export function GuideDetailScreen() {
               <View style={styles.placeNumber}>
                 <Text style={styles.placeNumberText}>{index + 1}</Text>
               </View>
-              <View
-                style={[
-                  styles.placeCategoryDot,
-                  { backgroundColor: colors.category[place.category] },
-                ]}
-              >
-                <SFIcon
-                  name={CATEGORY_ICONS[place.category].sf as any}
-                  fallback={CATEGORY_ICONS[place.category].fallback as any}
-                  size={14}
-                  color="#FFFFFF"
+              {mediaUrl ? (
+                <Image
+                  source={{ uri: mediaUrl }}
+                  style={styles.placeThumbnail}
+                  contentFit="cover"
+                  transition={200}
                 />
-              </View>
+              ) : (
+                <View
+                  style={[
+                    styles.placeCategoryDot,
+                    { backgroundColor: colors.category[place.category] },
+                  ]}
+                >
+                  <SFIcon
+                    name={CATEGORY_ICONS[place.category].sf as any}
+                    fallback={CATEGORY_ICONS[place.category].fallback as any}
+                    size={14}
+                    color="#FFFFFF"
+                  />
+                </View>
+              )}
               <View style={styles.placeInfo}>
                 <Text style={styles.placeName} numberOfLines={1}>
                   {place.name}
@@ -340,6 +390,22 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
+  },
+  heroContainer: {
+    height: 200,
+    position: "relative",
+  },
+  heroImage: {
+    width: "100%",
+    height: "100%",
+    backgroundColor: colors.gray200,
+  },
+  heroGradient: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: "60%",
   },
   header: {
     padding: 20,
@@ -419,10 +485,16 @@ const styles = StyleSheet.create({
     fontFamily: fonts.semiBold,
     color: colors.textSecondary,
   },
+  placeThumbnail: {
+    width: 48,
+    height: 48,
+    borderRadius: 8,
+    backgroundColor: colors.gray200,
+  },
   placeCategoryDot: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
+    width: 48,
+    height: 48,
+    borderRadius: 8,
     alignItems: "center",
     justifyContent: "center",
   },

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -1,4 +1,4 @@
-import type { Place, Event, Post, User, Guide, AIResponse } from '../types';
+import type { Place, Event, Post, User, GuideWithPlaces, AIResponse } from '../types';
 import { supabase } from '../lib/supabase';
 
 interface AIContext {
@@ -8,7 +8,7 @@ interface AIContext {
   followingUsers: User[];
   userLocation: { latitude: number; longitude: number } | null;
   trendingHashtags?: string[];
-  guides?: (Guide & { creatorName?: string })[];
+  guides?: GuideWithPlaces[];
 }
 
 export interface ConversationMessage {

--- a/src/services/guides.ts
+++ b/src/services/guides.ts
@@ -1,5 +1,48 @@
 import { supabase } from '../lib/supabase';
-import type { Guide, GuidePlace } from '../types';
+import { getTopPostMediaForPlaces } from './posts';
+import type { Guide, GuidePlace, GuideWithPlaces } from '../types';
+
+/** Enrich guides with place counts and first-place cover images. */
+async function enrichGuides(guides: Guide[]): Promise<Guide[]> {
+  if (guides.length === 0) return guides;
+
+  const guideIds = guides.map((g) => g.id);
+
+  // Fetch guide_places rows for counts and first place per guide
+  const { data: placeRows } = await supabase
+    .from('guide_places')
+    .select('guide_id, place_id, sort_order')
+    .in('guide_id', guideIds)
+    .order('sort_order', { ascending: true });
+
+  if (!placeRows) return guides;
+
+  const countMap = new Map<string, number>();
+  const firstPlaceMap = new Map<string, string>();
+  for (const row of placeRows) {
+    countMap.set(row.guide_id, (countMap.get(row.guide_id) ?? 0) + 1);
+    if (!firstPlaceMap.has(row.guide_id)) {
+      firstPlaceMap.set(row.guide_id, row.place_id);
+    }
+  }
+
+  // Fetch top post media for all first-place IDs
+  const firstPlaceIds = [...new Set(firstPlaceMap.values())];
+  const mediaMap = await getTopPostMediaForPlaces(firstPlaceIds);
+
+  for (const guide of guides) {
+    guide.placeCount = countMap.get(guide.id) ?? 0;
+    const firstPlaceId = firstPlaceMap.get(guide.id);
+    if (firstPlaceId) {
+      const media = mediaMap.get(firstPlaceId);
+      if (media) {
+        guide.firstPlaceImageUrl = media.thumbnailUrl ?? media.mediaUrl;
+      }
+    }
+  }
+
+  return guides;
+}
 
 export async function getGuides(): Promise<Guide[]> {
   const { data, error } = await supabase
@@ -8,29 +51,7 @@ export async function getGuides(): Promise<Guide[]> {
     .order('created_at', { ascending: false });
 
   if (error) throw error;
-
-  const guides = (data ?? []).map(mapGuide);
-
-  // Batch-fetch place counts
-  if (guides.length > 0) {
-    const guideIds = guides.map((g) => g.id);
-    const { data: placeRows } = await supabase
-      .from('guide_places')
-      .select('guide_id')
-      .in('guide_id', guideIds);
-
-    if (placeRows) {
-      const countMap = new Map<string, number>();
-      for (const row of placeRows) {
-        countMap.set(row.guide_id, (countMap.get(row.guide_id) ?? 0) + 1);
-      }
-      for (const guide of guides) {
-        guide.placeCount = countMap.get(guide.id) ?? 0;
-      }
-    }
-  }
-
-  return guides;
+  return enrichGuides((data ?? []).map(mapGuide));
 }
 
 export async function getGuidesByUserId(userId: string): Promise<Guide[]> {
@@ -41,29 +62,7 @@ export async function getGuidesByUserId(userId: string): Promise<Guide[]> {
     .order('created_at', { ascending: false });
 
   if (error) throw error;
-
-  const guides = (data ?? []).map(mapGuide);
-
-  // Batch-fetch place counts
-  if (guides.length > 0) {
-    const guideIds = guides.map((g) => g.id);
-    const { data: placeRows } = await supabase
-      .from('guide_places')
-      .select('guide_id')
-      .in('guide_id', guideIds);
-
-    if (placeRows) {
-      const countMap = new Map<string, number>();
-      for (const row of placeRows) {
-        countMap.set(row.guide_id, (countMap.get(row.guide_id) ?? 0) + 1);
-      }
-      for (const guide of guides) {
-        guide.placeCount = countMap.get(guide.id) ?? 0;
-      }
-    }
-  }
-
-  return guides;
+  return enrichGuides((data ?? []).map(mapGuide));
 }
 
 export async function getGuideById(guideId: string): Promise<Guide | null> {
@@ -111,29 +110,63 @@ export async function getGuidesByIds(ids: string[]): Promise<Guide[]> {
     .in('id', ids);
 
   if (error) throw error;
+  return enrichGuides((data ?? []).map(mapGuide));
+}
 
+export async function getGuidesWithPlaces(): Promise<GuideWithPlaces[]> {
+  const { data, error } = await supabase
+    .from('guides')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
   const guides = (data ?? []).map(mapGuide);
+  if (guides.length === 0) return [];
 
-  // Batch-fetch place counts
-  if (guides.length > 0) {
-    const guideIds = guides.map((g) => g.id);
-    const { data: placeRows } = await supabase
-      .from('guide_places')
-      .select('guide_id')
-      .in('guide_id', guideIds);
+  const guideIds = guides.map((g) => g.id);
 
-    if (placeRows) {
-      const countMap = new Map<string, number>();
-      for (const row of placeRows) {
-        countMap.set(row.guide_id, (countMap.get(row.guide_id) ?? 0) + 1);
-      }
-      for (const guide of guides) {
-        guide.placeCount = countMap.get(guide.id) ?? 0;
-      }
+  // Fetch guide_places joined with places for name/category
+  const { data: gpRows } = await supabase
+    .from('guide_places')
+    .select('guide_id, place_id, note, sort_order, places(name, category)')
+    .in('guide_id', guideIds)
+    .order('sort_order', { ascending: true });
+
+  // Fetch creator profiles
+  const userIds = [...new Set(guides.map((g) => g.userId))];
+  const { data: profiles } = await supabase
+    .from('profiles')
+    .select('id, display_name')
+    .in('id', userIds);
+
+  const profileMap = new Map<string, string>();
+  for (const p of profiles ?? []) {
+    if (p.display_name) profileMap.set(p.id, p.display_name);
+  }
+
+  // Group place details by guide
+  const guidePlacesMap = new Map<string, { name: string; category: string; note?: string }[]>();
+  const countMap = new Map<string, number>();
+  for (const row of gpRows ?? []) {
+    countMap.set(row.guide_id, (countMap.get(row.guide_id) ?? 0) + 1);
+    const place = row.places as unknown as { name: string; category: string } | null;
+    if (place) {
+      const arr = guidePlacesMap.get(row.guide_id) ?? [];
+      arr.push({
+        name: place.name,
+        category: place.category,
+        note: row.note ?? undefined,
+      });
+      guidePlacesMap.set(row.guide_id, arr);
     }
   }
 
-  return guides;
+  return guides.map((g) => ({
+    ...g,
+    placeCount: countMap.get(g.id) ?? 0,
+    creatorName: profileMap.get(g.userId),
+    places: guidePlacesMap.get(g.id) ?? [],
+  }));
 }
 
 export async function createGuide(params: {

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -197,6 +197,30 @@ export async function createPost(post: {
   return mapPost(data);
 }
 
+export async function getTopPostMediaForPlaces(
+  placeIds: string[]
+): Promise<Map<string, { mediaUrl: string; thumbnailUrl?: string }>> {
+  if (placeIds.length === 0) return new Map();
+
+  const { data } = await supabase
+    .from('posts')
+    .select('place_id, media_url, thumbnail_url, likes')
+    .in('place_id', placeIds)
+    .not('media_url', 'is', null)
+    .order('likes', { ascending: false });
+
+  const map = new Map<string, { mediaUrl: string; thumbnailUrl?: string }>();
+  for (const row of data ?? []) {
+    if (!map.has(row.place_id)) {
+      map.set(row.place_id, {
+        mediaUrl: row.media_url!,
+        thumbnailUrl: row.thumbnail_url ?? undefined,
+      });
+    }
+  }
+  return map;
+}
+
 function mapMediaItem(row: {
   id: string;
   media_url: string;

--- a/src/types/Guide.ts
+++ b/src/types/Guide.ts
@@ -4,6 +4,7 @@ export interface Guide {
   title: string;
   description?: string;
   coverImageUrl?: string;
+  firstPlaceImageUrl?: string;
   placeCount: number;
   createdAt: string;
   updatedAt: string;
@@ -15,4 +16,9 @@ export interface GuidePlace {
   sortOrder: number;
   note?: string;
   addedAt: string;
+}
+
+export interface GuideWithPlaces extends Guide {
+  creatorName?: string;
+  places: { name: string; category: string; note?: string }[];
 }

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -38,8 +38,10 @@ interface FollowingUser {
 interface Guide {
   id: string;
   title: string;
+  description?: string;
   placeCount: number;
   creatorName?: string;
+  places?: { name: string; category: string; note?: string }[];
 }
 
 interface AIContext {
@@ -186,8 +188,14 @@ ${followingStr || "Not following anyone yet."}
 RECENT POSTS FROM FOLLOWED USERS (user|place|content):
 ${postsStr || "No recent posts."}
 
-GUIDES (id|title|creator|placeCount):
-${ctx.guides?.length ? ctx.guides.map((g) => `${g.id}|${g.title}|${g.creatorName ?? "unknown"}|${g.placeCount} places`).join("\n") : "No guides yet."}
+GUIDES (curated place lists by users — recommend these when relevant to the user's query):
+${ctx.guides?.length ? ctx.guides.map((g) => {
+    const placesStr = g.places?.length
+      ? `\n  Places: ${g.places.map((p) => `${p.name} (${p.category})`).join(", ")}`
+      : "";
+    const descStr = g.description ? ` — "${g.description}"` : "";
+    return `${g.id}|"${g.title}" by ${g.creatorName ?? "unknown"} (${g.placeCount} places)${descStr}${placesStr}`;
+  }).join("\n") : "No guides yet."}
 
 TRENDING HASHTAGS:
 ${ctx.trendingHashtags?.length ? ctx.trendingHashtags.map((t) => `#${t}`).join(", ") : "None yet."}
@@ -213,7 +221,7 @@ INSTRUCTIONS:
 }
 - Only include places/events/guides that exist in the data above
 - Include 1-4 places, 0-3 events, and 0-2 guides as relevant to the question
-- When users ask for curated lists, recommendations from locals, or "best of" type questions, consider suggesting relevant guides
+- Check the GUIDES section for relevant guides to recommend. If a guide's title, description, or places match the user's query, include it in the guides array
 - When mentioning guides in message text, use: [Guide Title](guide:guideId)
 - When suggesting activities, you may reference relevant trending hashtags to help users discover related content
 - If the question is unrelated to Wellington activities, respond helpfully but keep places/events arrays empty`;


### PR DESCRIPTION
## Summary
- **AI chat now fetches guides directly** instead of reading from TanStack Query cache, so guides are always available regardless of which screens the user has visited
- **AI receives full guide details** (place names, categories, descriptions) enabling it to recommend relevant guides (e.g. "Date Night Spots" when asked about date nights)
- **Guide cards and detail screens show post media** — pulls the most popular post's image for each place as a cover/thumbnail, no user uploads needed

## Changes
- `src/types/Guide.ts` — Added `firstPlaceImageUrl` field and `GuideWithPlaces` type
- `src/services/posts.ts` — Added `getTopPostMediaForPlaces()` batch fetcher
- `src/services/guides.ts` — Shared `enrichGuides()` helper for cover images, new `getGuidesWithPlaces()` for AI context
- `src/services/ai.ts` — Updated `AIContext` to use `GuideWithPlaces`
- `src/screens/AIChatScreen.tsx` — Direct-fetches guides instead of cache read
- `src/screens/GuideDetailScreen.tsx` — Hero image + place thumbnails from post media
- `src/components/GuideCard.tsx` — Falls back to `firstPlaceImageUrl` for cover
- `supabase/functions/ai-chat/index.ts` — Enriched guide formatting in system prompt with descriptions and places

## Test plan
- [ ] Open AI chat without visiting SearchScreen first — ask about date nights, verify the "Date Night Spots" guide appears as a recommendation card
- [ ] View guide cards in search/profile — verify cover images from post media appear
- [ ] Open a guide detail screen — verify hero image and place thumbnails render
- [ ] Verify guides without any post media still show category dot fallbacks
- [ ] `npm run typecheck` and `npm run lint` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)