### PR TITLE
feat: add edit and delete events

### DIFF
--- a/src/screens/CreatePostSheetScreen.tsx
+++ b/src/screens/CreatePostSheetScreen.tsx
@@ -27,7 +27,7 @@ import { useToast } from "../context/ToastContext";
 import { findOrCreatePlace, getPlaceById } from "../services/places";
 import { createPost } from "../services/posts";
 import { uploadMedia } from "../services/storage";
-import { createEvent } from "../services/events";
+import { createEvent, updateEvent, getEventById } from "../services/events";
 import { createAchievementToast } from "../utils/achievementHelpers";
 import { compressMedia, compressAvatar } from "../utils/compressMedia";
 import * as ExpoVideoThumbnails from "expo-video-thumbnails";
@@ -56,10 +56,12 @@ export function CreatePostSheetScreen() {
     placeId: placeIdParam,
     defaultType,
     selectedPlaceData,
+    editEventId,
   } = useLocalSearchParams<{
     placeId?: string;
     defaultType?: CreateType;
     selectedPlaceData?: string;
+    editEventId?: string;
   }>();
   const router = useRouter();
   const pathname = usePathname();
@@ -68,8 +70,9 @@ export function CreatePostSheetScreen() {
 
   // Determine initial create type based on defaultType param (events tab -> event, otherwise -> post)
   const [createType, setCreateType] = useState<CreateType>(
-    defaultType || "post"
+    editEventId ? "event" : defaultType || "post"
   );
+  const isEditingEvent = !!editEventId;
 
   // Post-specific state
   const [content, setContent] = useState("");
@@ -182,6 +185,39 @@ export function CreatePostSheetScreen() {
       scrollViewRef.current?.scrollToEnd({ animated: true });
     }
   }, [keyboardVisible]);
+
+  // Load existing event data for editing
+  useEffect(() => {
+    if (!editEventId) return;
+    getEventById(editEventId).then(async (event) => {
+      if (!event) return;
+      setEventTitle(event.title);
+      setEventDescription(event.description);
+      setEventCategory(event.category);
+      setEventDate(new Date(event.date + "T00:00:00"));
+      if (event.startTime) {
+        const [h, m] = event.startTime.split(":");
+        const d = new Date();
+        d.setHours(parseInt(h, 10), parseInt(m, 10), 0, 0);
+        setEventStartTime(d);
+      }
+      if (event.endTime) {
+        const [h, m] = event.endTime.split(":");
+        const d = new Date();
+        d.setHours(parseInt(h, 10), parseInt(m, 10), 0, 0);
+        setEventEndTime(d);
+      }
+      if (event.imageUrl) {
+        setEventImageUri(event.imageUrl);
+      }
+      if (event.price != null) {
+        setEventPrice(event.price > 0 ? event.price.toString() : "");
+      }
+      // Load the associated place
+      const place = await getPlaceById(event.placeId);
+      if (place) setSelectedPlace(place);
+    });
+  }, [editEventId]);
 
   // Handle place selection from search sheet
   useFocusEffect(
@@ -433,9 +469,15 @@ export function CreatePostSheetScreen() {
         let imageUrl: string | undefined;
 
         if (eventImageUri) {
-          const compressedUri = await compressMedia(eventImageUri, "photo");
-          const fileName = `${profile.id}-event-${Date.now()}.jpg`;
-          imageUrl = await uploadMedia(profile.id, compressedUri, fileName, "image/jpeg");
+          const isRemoteUrl = eventImageUri.startsWith("http");
+          if (isRemoteUrl) {
+            // Existing remote image — no need to re-upload
+            imageUrl = eventImageUri;
+          } else {
+            const compressedUri = await compressMedia(eventImageUri, "photo");
+            const fileName = `${profile.id}-event-${Date.now()}.jpg`;
+            imageUrl = await uploadMedia(profile.id, compressedUri, fileName, "image/jpeg");
+          }
         }
 
         const dateStr = eventDate!.toISOString().split("T")[0];
@@ -445,43 +487,64 @@ export function CreatePostSheetScreen() {
           ? `${pad(eventEndTime.getHours())}:${pad(eventEndTime.getMinutes())}`
           : undefined;
 
-        await createEvent({
-          title: eventTitle.trim(),
-          description: eventDescription.trim(),
-          placeId: placeId,
-          date: dateStr,
-          startTime: startTimeStr,
-          endTime: endTimeStr,
-          imageUrl,
-          category: eventCategory,
-          creatorId: profile.id,
-          price: eventPrice.trim() ? parseFloat(eventPrice) || null : null,
-        });
+        if (isEditingEvent) {
+          await updateEvent(editEventId!, {
+            title: eventTitle.trim(),
+            description: eventDescription.trim(),
+            placeId: placeId,
+            date: dateStr,
+            startTime: startTimeStr,
+            endTime: endTimeStr,
+            imageUrl: imageUrl ?? (eventImageUri ? undefined : null),
+            category: eventCategory,
+            price: eventPrice.trim() ? parseFloat(eventPrice) || null : null,
+          });
 
-        // Invalidate event caches so events screen shows the new event
-        queryClient.invalidateQueries({ queryKey: ['q', 'events'] });
-        queryClient.invalidateQueries({ queryKey: ['q', 'upcoming-events'] });
+          queryClient.invalidateQueries({ queryKey: ['q', 'events'] });
+          queryClient.invalidateQueries({ queryKey: ['q', 'upcoming-events'] });
+          queryClient.invalidateQueries({ queryKey: ['q', ['event', editEventId]] });
 
-        Alert.alert(
-          "Event Created!",
-          `"${eventTitle}" at ${selectedPlace.name} has been created.`,
-          [
-            {
-              text: "OK",
-              onPress: () => {
-                setEventTitle("");
-                setEventDescription("");
-                setEventDate(null);
-                setEventStartTime(null);
-                setEventEndTime(null);
-                setEventImageUri(null);
-                setEventPrice("");
-                setSelectedPlace(null);
-                router.dismiss();
+          showToast({ message: "Event updated" });
+          router.dismiss();
+        } else {
+          await createEvent({
+            title: eventTitle.trim(),
+            description: eventDescription.trim(),
+            placeId: placeId,
+            date: dateStr,
+            startTime: startTimeStr,
+            endTime: endTimeStr,
+            imageUrl,
+            category: eventCategory,
+            creatorId: profile.id,
+            price: eventPrice.trim() ? parseFloat(eventPrice) || null : null,
+          });
+
+          // Invalidate event caches so events screen shows the new event
+          queryClient.invalidateQueries({ queryKey: ['q', 'events'] });
+          queryClient.invalidateQueries({ queryKey: ['q', 'upcoming-events'] });
+
+          Alert.alert(
+            "Event Created!",
+            `"${eventTitle}" at ${selectedPlace.name} has been created.`,
+            [
+              {
+                text: "OK",
+                onPress: () => {
+                  setEventTitle("");
+                  setEventDescription("");
+                  setEventDate(null);
+                  setEventStartTime(null);
+                  setEventEndTime(null);
+                  setEventImageUri(null);
+                  setEventPrice("");
+                  setSelectedPlace(null);
+                  router.dismiss();
+                },
               },
-            },
-          ]
-        );
+            ]
+          );
+        }
       }
     } catch (error: any) {
       Alert.alert("Error", error.message ?? `Failed to create ${createType}`);
@@ -534,7 +597,9 @@ export function CreatePostSheetScreen() {
                 </HapticPressable>
               </View>
               <View style={styles.headerCenter}>
-                {glassEnabled ? (
+                {isEditingEvent ? (
+                  <Text style={styles.editTitle}>Edit Event</Text>
+                ) : glassEnabled ? (
                   <GlassView style={styles.segmentControlGlass} glassEffectStyle="regular">
                     <HapticPressable
                       style={[styles.segment, createType === "post" && styles.segmentActiveGlass]}
@@ -576,7 +641,7 @@ export function CreatePostSheetScreen() {
               </View>
               <View style={styles.headerRight}>
                 <LiquidGlassButton
-                  title="Create"
+                  title={isEditingEvent ? "Save" : "Create"}
                   onPress={handleSubmit}
                   disabled={!isFormValid() || posting}
                   size="medium"
@@ -655,7 +720,7 @@ export function CreatePostSheetScreen() {
           <View style={styles.progressContent}>
             <ActivityIndicator size="large" color={colors.primary} />
             <Text style={styles.progressText}>
-              {createType === "post" ? "Posting..." : "Creating event..."}
+              {createType === "post" ? "Posting..." : isEditingEvent ? "Saving..." : "Creating event..."}
             </Text>
             <Text style={styles.progressSubtext}>This may take a moment</Text>
           </View>
@@ -700,6 +765,11 @@ const styles = StyleSheet.create({
     height: 40,
     alignItems: "center",
     justifyContent: "center",
+  },
+  editTitle: {
+    fontSize: 17,
+    fontFamily: fonts.semiBold,
+    color: colors.text,
   },
   segmentControl: {
     flexDirection: "row",

--- a/src/screens/EventDetailScreen.tsx
+++ b/src/screens/EventDetailScreen.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   View,
   Text,
@@ -8,17 +15,23 @@ import {
   ActivityIndicator,
   Alert,
 } from "react-native";
-import { useLocalSearchParams, useRouter, useFocusEffect } from "expo-router";
+import {
+  useLocalSearchParams,
+  useRouter,
+  useNavigation,
+  usePathname,
+  useFocusEffect,
+} from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { SFIcon } from "../components/SFIcon";
 import { LinearGradient } from "expo-linear-gradient";
-import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect";
 import * as WebBrowser from "expo-web-browser";
 import {
   getEventById,
   getEventAttendees,
   toggleAttendance,
+  deleteEvent,
 } from "../services/events";
 import { getPlaceById } from "../services/places";
 import { getProfilesByIds } from "../services/users";
@@ -26,12 +39,14 @@ import { useQuery } from "../hooks/useQuery";
 import { useAuth } from "../context/AuthContext";
 import { useFollow } from "../context/FollowContext";
 import { addToCalendar } from "../utils/addToCalendar";
+import { useToast } from "../context/ToastContext";
 import { colors } from "../theme/colors";
 import type { Event } from "../types";
 import { shareEvent } from "../utils/sharing";
 import { useSave } from "../context/SaveContext";
 import { HapticPressable } from "src/components/HapticPressable";
 import { LiquidGlassButton } from "../components/LiquidGlassButton";
+import { ContextMenu, Button as ExpoButton, Host } from "@expo/ui/swift-ui";
 import { fonts } from "../theme/fonts";
 
 const CATEGORY_COLORS: Record<Event["category"], string> = {
@@ -86,30 +101,26 @@ function formatTime(time: string, endTime?: string): string {
   return formatSingleTime(time);
 }
 
-function getMonth(dateString: string): string {
-  const date = new Date(dateString);
-  return date.toLocaleDateString("en-NZ", { month: "short" }).toUpperCase();
-}
-
-function getDay(dateString: string): string {
-  const date = new Date(dateString);
-  return date.getDate().toString();
-}
-
-const glassEnabled = isLiquidGlassAvailable();
-
 export function EventDetailScreen() {
   const { eventId } = useLocalSearchParams<{ eventId: string }>();
   const router = useRouter();
+  const navigation = useNavigation();
+  const pathname = usePathname();
   const insets = useSafeAreaInsets();
   const headerHeight = useHeaderHeight();
-  const { session } = useAuth();
+  const { session, profile } = useAuth();
   const { followingIds } = useFollow();
   const { isSaved, toggleSave } = useSave();
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const [togglingAttendance, setTogglingAttendance] = useState(false);
 
   const fetchEvent = useCallback(() => getEventById(eventId), [eventId]);
-  const { data: event, loading, refetch: refetchEvent } = useQuery(fetchEvent, ['event', eventId]);
+  const {
+    data: event,
+    loading,
+    refetch: refetchEvent,
+  } = useQuery(fetchEvent, ["event", eventId]);
 
   const fetchPlace = useCallback(
     () => (event ? getPlaceById(event.placeId) : Promise.resolve(null)),
@@ -150,6 +161,53 @@ export function EventDetailScreen() {
     }, [refetchEvent, refetchAttendees])
   );
 
+  const isOwnEvent =
+    event?.creatorId != null && event.creatorId === profile?.id;
+  const onEditRef = useRef<(() => void) | undefined>(undefined);
+  const onDeleteRef = useRef<(() => void) | undefined>(undefined);
+
+  useLayoutEffect(() => {
+    if (!isOwnEvent) return;
+    navigation.setOptions({
+      headerRight: () => (
+        <Host matchContents>
+          <ContextMenu activationMethod="singlePress">
+            <ContextMenu.Trigger>
+              <View
+                style={{
+                  alignItems: "center",
+                  justifyContent: "center",
+                  paddingHorizontal: 7,
+                }}
+              >
+                <SFIcon
+                  name="ellipsis"
+                  fallback="ellipsis-horizontal"
+                  size={22}
+                />
+              </View>
+            </ContextMenu.Trigger>
+            <ContextMenu.Items>
+              <ExpoButton
+                systemImage="pencil"
+                onPress={() => onEditRef.current?.()}
+              >
+                Edit event
+              </ExpoButton>
+              <ExpoButton
+                systemImage="trash"
+                role="destructive"
+                onPress={() => onDeleteRef.current?.()}
+              >
+                Delete event
+              </ExpoButton>
+            </ContextMenu.Items>
+          </ContextMenu>
+        </Host>
+      ),
+    });
+  }, [navigation, isOwnEvent]);
+
   if (loading) {
     return (
       <View
@@ -164,6 +222,41 @@ export function EventDetailScreen() {
   }
 
   if (!event) return null;
+
+  const tabBase = "/" + pathname.split("/")[1];
+
+  onEditRef.current = () => {
+    router.push({
+      pathname: `${tabBase}/create-post` as any,
+      params: { editEventId: event.id },
+    });
+  };
+
+  onDeleteRef.current = () => {
+    Alert.alert("Delete event?", "This cannot be undone.", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await deleteEvent(event.id);
+            queryClient.invalidateQueries({ queryKey: ["q", "events"] });
+            queryClient.invalidateQueries({
+              queryKey: ["q", "upcoming-events"],
+            });
+            queryClient.invalidateQueries({
+              queryKey: ["q", ["event", event.id]],
+            });
+            showToast({ message: "Event deleted" });
+            router.back();
+          } catch (err: any) {
+            Alert.alert("Error", err?.message ?? "Failed to delete event");
+          }
+        },
+      },
+    ]);
+  };
 
   const currentUserId = session?.user?.id;
   const isGoing = currentUserId
@@ -220,22 +313,6 @@ export function EventDetailScreen() {
                 style={styles.heroGradient}
               />
 
-              {/* Date badge (top-right) */}
-              {glassEnabled ? (
-                <GlassView
-                  glassEffectStyle="regular"
-                  style={styles.heroDateBadge}
-                >
-                  <Text style={[styles.heroDateMonth, styles.heroDateMonthGlass]}>{getMonth(event.date)}</Text>
-                  <Text style={[styles.heroDateDay, styles.heroDateDayGlass]}>{getDay(event.date)}</Text>
-                </GlassView>
-              ) : (
-                <View style={[styles.heroDateBadge, styles.heroDateBadgeFallback]}>
-                  <Text style={styles.heroDateMonth}>{getMonth(event.date)}</Text>
-                  <Text style={styles.heroDateDay}>{getDay(event.date)}</Text>
-                </View>
-              )}
-
               {/* Title overlaid on bottom */}
               <Text style={styles.heroTitle} numberOfLines={3}>
                 {event.title}
@@ -253,15 +330,23 @@ export function EventDetailScreen() {
                 />
                 <Text style={styles.infoText}>{formatDate(event.date)}</Text>
                 <HapticPressable
-                  onPress={() => toggleSave('event', event.id)}
+                  onPress={() => toggleSave("event", event.id)}
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                   style={styles.shareButton}
                 >
                   <SFIcon
-                    name={isSaved('event', event.id) ? "bookmark.fill" : "bookmark"}
-                    fallback={isSaved('event', event.id) ? "bookmark" : "bookmark-outline"}
+                    name={
+                      isSaved("event", event.id) ? "bookmark.fill" : "bookmark"
+                    }
+                    fallback={
+                      isSaved("event", event.id)
+                        ? "bookmark"
+                        : "bookmark-outline"
+                    }
                     size={20}
-                    color={isSaved('event', event.id) ? colors.saved : colors.text}
+                    color={
+                      isSaved("event", event.id) ? colors.saved : colors.text
+                    }
                   />
                 </HapticPressable>
                 <HapticPressable
@@ -286,7 +371,12 @@ export function EventDetailScreen() {
                 </HapticPressable>
               </View>
               <View style={styles.infoRow}>
-                <SFIcon name="clock" fallback="time" size={18} color={colors.textSecondary} />
+                <SFIcon
+                  name="clock"
+                  fallback="time"
+                  size={18}
+                  color={colors.textSecondary}
+                />
                 <Text style={styles.infoText}>
                   {formatTime(event.startTime, event.endTime)}
                 </Text>
@@ -448,50 +538,6 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     height: "65%",
-  },
-  heroDateBadge: {
-    position: "absolute",
-    top: 60,
-    right: 16,
-    borderRadius: 10,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    alignItems: "center",
-    minWidth: 52,
-    overflow: "hidden",
-  },
-  heroDateBadgeFallback: {
-    backgroundColor: "#FFFFFF",
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.15,
-    shadowRadius: 4,
-    elevation: 3,
-  },
-  heroDateMonth: {
-    fontSize: 11,
-    fontWeight: "700",
-    fontFamily: fonts.bold,
-    color: colors.primary,
-    letterSpacing: 0.5,
-  },
-  heroDateMonthGlass: {
-    color: "#FFFFFF",
-    textShadowColor: "rgba(0,0,0,0.3)",
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 2,
-  },
-  heroDateDay: {
-    fontSize: 24,
-    fontFamily: fonts.extraBold,
-    color: colors.text,
-    lineHeight: 28,
-  },
-  heroDateDayGlass: {
-    color: "#FFFFFF",
-    textShadowColor: "rgba(0,0,0,0.3)",
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 2,
   },
   heroTitle: {
     position: "absolute",

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -175,6 +175,7 @@ export async function createEvent(params: {
       image_url: params.imageUrl ?? null,
       category: params.category,
       price: params.price ?? null,
+      creator_id: params.creatorId,
     })
     .select()
     .single();
@@ -187,6 +188,57 @@ export async function createEvent(params: {
     .insert({ event_id: data.id, user_id: params.creatorId });
 
   return mapEvent(data);
+}
+
+export async function updateEvent(
+  eventId: string,
+  params: {
+    title?: string;
+    description?: string;
+    placeId?: string;
+    date?: string;
+    startTime?: string;
+    endTime?: string | null;
+    imageUrl?: string | null;
+    category?: Event['category'];
+    price?: number | null;
+  }
+): Promise<Event> {
+  const updateData: Record<string, unknown> = {};
+  if (params.title !== undefined) updateData.title = params.title;
+  if (params.description !== undefined) updateData.description = params.description;
+  if (params.placeId !== undefined) updateData.place_id = params.placeId;
+  if (params.date !== undefined) updateData.date = params.date;
+  if (params.startTime !== undefined) updateData.start_time = params.startTime;
+  if (params.endTime !== undefined) updateData.end_time = params.endTime;
+  if (params.imageUrl !== undefined) updateData.image_url = params.imageUrl;
+  if (params.category !== undefined) updateData.category = params.category;
+  if (params.price !== undefined) updateData.price = params.price;
+
+  const { data, error } = await supabase
+    .from('events')
+    .update(updateData)
+    .eq('id', eventId)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return mapEvent(data);
+}
+
+export async function deleteEvent(eventId: string): Promise<void> {
+  // Delete attendees first (foreign key constraint)
+  await supabase
+    .from('event_attendees')
+    .delete()
+    .eq('event_id', eventId);
+
+  const { error } = await supabase
+    .from('events')
+    .delete()
+    .eq('id', eventId);
+
+  if (error) throw error;
 }
 
 function mapEvent(row: {
@@ -202,6 +254,7 @@ function mapEvent(row: {
   ticket_url: string | null;
   price: number | null;
   created_at: string;
+  creator_id?: string | null;
 }): Event {
   return {
     id: row.id,
@@ -215,5 +268,6 @@ function mapEvent(row: {
     category: row.category as Event['category'],
     ticketUrl: row.ticket_url ?? undefined,
     price: row.price,
+    creatorId: row.creator_id ?? undefined,
   };
 }

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -13,4 +13,5 @@ export interface Event {
   attendeeIds?: string[];
   ticketUrl?: string;
   price?: number | null;
+  creatorId?: string;
 }

--- a/supabase/migrations/20260222300000_add_event_creator.sql
+++ b/supabase/migrations/20260222300000_add_event_creator.sql
@@ -1,0 +1,12 @@
+-- Add creator_id to events table
+ALTER TABLE events ADD COLUMN creator_id uuid REFERENCES profiles(id);
+
+-- RLS policies for event owners
+CREATE POLICY "Users can update own events"
+  ON events FOR UPDATE
+  USING (auth.uid() = creator_id)
+  WITH CHECK (auth.uid() = creator_id);
+
+CREATE POLICY "Users can delete own events"
+  ON events FOR DELETE
+  USING (auth.uid() = creator_id);


### PR DESCRIPTION
## Summary
- Add `creator_id` column to events table with RLS policies for owner-only update/delete
- Add context menu (ellipsis) in EventDetailScreen header for event owners with "Edit event" and "Delete event" actions
- Support event editing in CreatePostSheetScreen via `editEventId` param — pre-fills all fields, calls `updateEvent` on save
- Remove redundant hero date badge from event detail view (date already shown in info section)
- Fix remote image handling to skip compression/upload for existing event images

## Test plan
- [ ] Create a new event and verify the context menu (ellipsis) appears in the header
- [ ] Tap "Edit event" and verify all fields are pre-filled correctly
- [ ] Modify fields and save — verify changes persist
- [ ] Tap "Delete event" and confirm — verify event is removed
- [ ] View an event created by another user — verify no context menu appears
- [ ] Verify hero date badge is removed from event detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)