### PR TITLE
feat: network error handling & offline detection

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useCallback } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "../src/lib/queryClient";
+import { setupNetworkManager } from "../src/lib/networkManager";
 import { Slot, useRouter, useSegments } from "expo-router";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useShareIntent } from "expo-share-intent";
 import * as SplashScreen from "expo-splash-screen";
 import { ErrorScreen } from "../src/components/ErrorScreen";
+import { OfflineBanner } from "../src/components/OfflineBanner";
 import {
   useFonts,
   PlusJakartaSans_500Medium,
@@ -18,6 +20,7 @@ import { Pacifico_400Regular } from "@expo-google-fonts/pacifico";
 import { AuthProvider, useAuth } from "../src/context/AuthContext";
 import { ThemeProvider } from "../src/theme/ThemeContext";
 
+import { NetworkProvider } from "../src/context/NetworkContext";
 import { FollowProvider } from "../src/context/FollowContext";
 import { LikeProvider } from "../src/context/LikeContext";
 import { SaveProvider } from "../src/context/SaveContext";
@@ -32,6 +35,7 @@ export function ErrorBoundary({ error, retry }: { error: Error; retry: () => voi
   return <ErrorScreen error={error} retry={retry} />;
 }
 
+setupNetworkManager();
 SplashScreen.preventAutoHideAsync();
 
 const WEBSITE_HOST = (
@@ -216,6 +220,7 @@ export default function RootLayout() {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <NetworkProvider>
       <ThemeProvider>
       <GestureHandlerRootView style={{ flex: 1 }} onLayout={onLayoutRootView}>
         <ZoomOverlayProvider>
@@ -230,6 +235,7 @@ export default function RootLayout() {
                         <ExplorationProvider>
                           <AuthGate>
                             <Slot />
+                            <OfflineBanner />
                           </AuthGate>
                           <StatusBar style="auto" />
                         </ExplorationProvider>
@@ -244,6 +250,7 @@ export default function RootLayout() {
         </ZoomOverlayProvider>
       </GestureHandlerRootView>
       </ThemeProvider>
+      </NetworkProvider>
     </QueryClientProvider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/datetimepicker": "8.4.4",
+        "@react-native-community/netinfo": "11.4.1",
         "@react-navigation/drawer": "^7.5.0",
         "@react-navigation/elements": "^2.9.5",
         "@shopify/react-native-skia": "2.2.12",
@@ -3978,6 +3979,15 @@
         "react-native-windows": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
+      "integrity": "sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.4.4",
+    "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/drawer": "^7.5.0",
     "@react-navigation/elements": "^2.9.5",
     "@shopify/react-native-skia": "2.2.12",

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+import { Animated, StyleSheet, Text } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useNetwork } from "../context/NetworkContext";
+import { useTheme, type Colors } from "../theme/ThemeContext";
+import { SFIcon } from "./SFIcon";
+import { fonts } from "../theme/fonts";
+
+export function OfflineBanner() {
+  const { isConnected } = useNetwork();
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const translateY = useRef(new Animated.Value(-100)).current;
+
+  useEffect(() => {
+    Animated.spring(translateY, {
+      toValue: isConnected ? -100 : 0,
+      useNativeDriver: true,
+    }).start();
+  }, [isConnected, translateY]);
+
+  const styles = createStyles(colors, insets.top);
+
+  return (
+    <Animated.View
+      style={[styles.container, { transform: [{ translateY }] }]}
+      pointerEvents="none"
+    >
+      <SFIcon
+        name="wifi.slash"
+        fallback="cloud-offline-outline"
+        size={16}
+        color="#FFFFFF"
+      />
+      <Text style={styles.text}>You&apos;re offline</Text>
+    </Animated.View>
+  );
+}
+
+const createStyles = (colors: Colors, topInset: number) =>
+  StyleSheet.create({
+    container: {
+      position: "absolute",
+      top: 0,
+      left: 0,
+      right: 0,
+      paddingTop: topInset + 4,
+      paddingBottom: 8,
+      paddingHorizontal: 16,
+      backgroundColor: colors.warning,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 8,
+      zIndex: 9999,
+    },
+    text: {
+      color: "#FFFFFF",
+      fontSize: 14,
+      fontFamily: fonts.semiBold,
+    },
+  });

--- a/src/components/QueryErrorState.tsx
+++ b/src/components/QueryErrorState.tsx
@@ -1,0 +1,82 @@
+import { View, Text, StyleSheet } from "react-native";
+import { useNetwork } from "../context/NetworkContext";
+import { useTheme, type Colors } from "../theme/ThemeContext";
+import { HapticPressable } from "./HapticPressable";
+import { SFIcon } from "./SFIcon";
+import { fonts } from "../theme/fonts";
+
+interface QueryErrorStateProps {
+  message?: string | null;
+  onRetry?: () => void;
+  fullScreen?: boolean;
+}
+
+export function QueryErrorState({
+  message,
+  onRetry,
+  fullScreen = true,
+}: QueryErrorStateProps) {
+  const { isConnected } = useNetwork();
+  const { colors } = useTheme();
+  const styles = createStyles(colors, fullScreen);
+
+  const isOffline = !isConnected;
+  const title = isOffline ? "You're offline" : "Something went wrong";
+  const subtitle = isOffline
+    ? "Check your connection and try again"
+    : message || "An unexpected error occurred";
+
+  return (
+    <View style={styles.container}>
+      <SFIcon
+        name={isOffline ? "wifi.slash" : "exclamationmark.triangle.fill"}
+        fallback={isOffline ? "cloud-offline-outline" : "warning-outline"}
+        size={40}
+        color={colors.textMuted}
+      />
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.message}>{subtitle}</Text>
+      {onRetry && (
+        <HapticPressable style={styles.button} onPress={onRetry}>
+          <Text style={styles.buttonText}>Try Again</Text>
+        </HapticPressable>
+      )}
+    </View>
+  );
+}
+
+const createStyles = (colors: Colors, fullScreen: boolean) =>
+  StyleSheet.create({
+    container: {
+      flex: fullScreen ? 1 : undefined,
+      backgroundColor: fullScreen ? colors.background : undefined,
+      alignItems: "center",
+      justifyContent: "center",
+      padding: 32,
+    },
+    title: {
+      fontSize: 20,
+      fontFamily: fonts.bold,
+      color: colors.text,
+      marginTop: 16,
+      marginBottom: 8,
+    },
+    message: {
+      fontSize: 14,
+      fontFamily: fonts.medium,
+      color: colors.textSecondary,
+      textAlign: "center",
+      marginBottom: 24,
+    },
+    button: {
+      backgroundColor: colors.primary,
+      paddingHorizontal: 24,
+      paddingVertical: 12,
+      borderRadius: 12,
+    },
+    buttonText: {
+      fontSize: 16,
+      fontFamily: fonts.semiBold,
+      color: "#FFFFFF",
+    },
+  });

--- a/src/context/FollowContext.tsx
+++ b/src/context/FollowContext.tsx
@@ -23,7 +23,7 @@ export function FollowProvider({ children }: { children: React.ReactNode }) {
     if (!currentUserId) return;
     getFollowingIds(currentUserId)
       .then(setFollowingIds)
-      .catch(() => {});
+      .catch((e) => console.warn('Failed to load following IDs:', e));
   }, [currentUserId]);
 
   useEffect(() => {

--- a/src/context/LikeContext.tsx
+++ b/src/context/LikeContext.tsx
@@ -28,10 +28,10 @@ export function LikeProvider({ children }: { children: React.ReactNode }) {
     if (!currentUserId) return;
     getLikedPostIds(currentUserId)
       .then(setLikedPostIds)
-      .catch(() => {});
+      .catch((e) => console.warn('Failed to load liked post IDs:', e));
     getAllLikeCounts()
       .then(setLikeCounts)
-      .catch(() => {});
+      .catch((e) => console.warn('Failed to load like counts:', e));
   }, [currentUserId]);
 
   useEffect(() => {

--- a/src/context/NetworkContext.tsx
+++ b/src/context/NetworkContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+import NetInfo from "@react-native-community/netinfo";
+
+interface NetworkContextType {
+  isConnected: boolean;
+}
+
+const NetworkContext = createContext<NetworkContextType>({ isConnected: true });
+
+export function NetworkProvider({ children }: { children: React.ReactNode }) {
+  const [isConnected, setIsConnected] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      setIsConnected(state.isConnected !== false);
+    });
+    return unsubscribe;
+  }, []);
+
+  return (
+    <NetworkContext.Provider value={{ isConnected }}>
+      {children}
+    </NetworkContext.Provider>
+  );
+}
+
+export function useNetwork() {
+  return useContext(NetworkContext);
+}

--- a/src/context/NotificationContext.tsx
+++ b/src/context/NotificationContext.tsx
@@ -38,7 +38,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         setNotifications(notifs);
         setUnreadCount(count);
       })
-      .catch(() => {});
+      .catch((e) => console.warn('Failed to load notifications:', e));
   }, [currentUserId]);
 
   // Initial load
@@ -59,7 +59,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       if (AppState.currentState === 'active') {
         fetchUnreadCount(currentUserId)
           .then(setUnreadCount)
-          .catch(() => {});
+          .catch((e) => console.warn('Failed to poll unread count:', e));
       }
     }, 30000);
 

--- a/src/context/SaveContext.tsx
+++ b/src/context/SaveContext.tsx
@@ -31,7 +31,7 @@ export function SaveProvider({ children }: { children: React.ReactNode }) {
         setSavedEvents(events);
         setSavedGuides(guides);
       })
-      .catch(() => {});
+      .catch((e) => console.warn('Failed to load saved items:', e));
   }, [currentUserId]);
 
   useEffect(() => {

--- a/src/hooks/useMapData.ts
+++ b/src/hooks/useMapData.ts
@@ -36,27 +36,32 @@ export function useMapData({
   const {
     data: places,
     loading: placesLoading,
+    error: placesError,
     refetch: refetchPlaces,
   } = useQuery(getPlaces, "places");
   const allPlaces = places ?? [];
   const {
     data: allPosts,
     loading: postsLoading,
+    error: postsError,
     refetch: refetchPosts,
   } = useQuery(getPosts, "posts");
   const {
     data: allUsers,
     loading: usersLoading,
+    error: usersError,
     refetch: refetchUsers,
   } = useQuery(getProfiles, "profiles");
-  const { data: trails, refetch: refetchTrails } = useQuery(
+  const { data: trails, error: trailsError, refetch: refetchTrails } = useQuery(
     getTrails,
     "trails"
   );
-  const { data: upcomingEvents, refetch: refetchEvents } = useQuery(
+  const { data: upcomingEvents, error: eventsError, refetch: refetchEvents } = useQuery(
     getUpcomingEvents,
     "upcoming-events"
   );
+
+  const error = placesError || postsError || usersError || trailsError || eventsError;
 
   const todayEvents = useMemo(() => {
     const now = new Date();
@@ -236,6 +241,7 @@ export function useMapData({
   return {
     places,
     trails,
+    error,
     isDataLoaded,
     isInitialLoad,
     filteredPlaces,
@@ -243,5 +249,6 @@ export function useMapData({
     baseMarkerDataMap,
     placeEventsMap,
     popularityMap,
+    refetchAll,
   };
 }

--- a/src/lib/networkManager.ts
+++ b/src/lib/networkManager.ts
@@ -1,0 +1,11 @@
+import NetInfo from "@react-native-community/netinfo";
+import { onlineManager } from "@tanstack/react-query";
+
+export function setupNetworkManager() {
+  onlineManager.setEventListener((setOnline) => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      setOnline(!!state.isConnected);
+    });
+    return unsubscribe;
+  });
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -8,6 +8,7 @@ export const queryClient = new QueryClient({
         return failureCount < 2;
       },
       staleTime: 2 * 60 * 1000, // 2 minutes
+      networkMode: "offlineFirst",
     },
   },
 });

--- a/src/screens/DiscoverUsersScreen.tsx
+++ b/src/screens/DiscoverUsersScreen.tsx
@@ -13,6 +13,7 @@ import { Pressable } from 'react-native';
 import { useQuery } from '../hooks/useQuery';
 import { getOtherProfiles } from '../services/users';
 import { HapticPressable } from 'src/components/HapticPressable';
+import { QueryErrorState } from '../components/QueryErrorState';
 
 export function DiscoverUsersScreen() {
   const { colors } = useTheme();
@@ -26,7 +27,7 @@ export function DiscoverUsersScreen() {
   const { profile } = useAuth();
 
   const fetchUsers = useCallback(() => getOtherProfiles(profile?.id ?? ''), [profile?.id]);
-  const { data: otherUsers, loading, refetch: refetchUsers } = useQuery(fetchUsers, profile?.id);
+  const { data: otherUsers, loading, error: usersError, refetch: refetchUsers } = useQuery(fetchUsers, profile?.id);
   const allUsers = Array.isArray(otherUsers) ? otherUsers : [];
 
   // Refetch when screen comes into focus
@@ -42,6 +43,10 @@ export function DiscoverUsersScreen() {
     const bFollowed = isFollowing(b.id) ? 1 : 0;
     return aFollowed - bFollowed;
   }), [allUsers, isFollowing]);
+
+  if (usersError && !otherUsers) {
+    return <QueryErrorState message={usersError} onRetry={refetchUsers} />;
+  }
 
   return (
     <View style={styles.container}>

--- a/src/screens/EventDetailScreen.tsx
+++ b/src/screens/EventDetailScreen.tsx
@@ -25,6 +25,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { SFIcon } from "../components/SFIcon";
+import { QueryErrorState } from "../components/QueryErrorState";
 import { LinearGradient } from "expo-linear-gradient";
 import * as WebBrowser from "expo-web-browser";
 import {
@@ -120,6 +121,7 @@ export function EventDetailScreen() {
   const {
     data: event,
     loading,
+    error: eventError,
     refetch: refetchEvent,
   } = useQuery(fetchEvent, ["event", eventId]);
 
@@ -222,6 +224,10 @@ export function EventDetailScreen() {
         <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
+  }
+
+  if (eventError && !event) {
+    return <QueryErrorState message={eventError} onRetry={refetchEvent} />;
   }
 
   if (!event) return null;

--- a/src/screens/EventsScreen.tsx
+++ b/src/screens/EventsScreen.tsx
@@ -23,6 +23,7 @@ import { useEventFilters } from "../context/EventFilterContext";
 import { useTheme, type Colors } from "../theme/ThemeContext";
 import { HapticPressable } from "src/components/HapticPressable";
 import { FloatingCreateButton } from "src/components/FloatingCreateButton";
+import { QueryErrorState } from "../components/QueryErrorState";
 import { fonts } from "../theme/fonts";
 
 type DateRange = "today" | "tomorrow" | "weekend" | "month";
@@ -165,6 +166,7 @@ export function EventsScreen() {
   const {
     data: events,
     loading: loadingEvents,
+    error: eventsError,
     refetch: refetchEvents,
   } = useQuery(fetchEvents, "events");
 
@@ -297,6 +299,10 @@ export function EventsScreen() {
         <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
+  }
+
+  if (eventsError && !events) {
+    return <QueryErrorState message={eventsError} onRetry={refetchEvents} />;
   }
 
   return (

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -15,6 +15,7 @@ import { getPlaces } from "../services/places";
 import { sortPosts } from "../utils/postSorting";
 import { HapticPressable } from "src/components/HapticPressable";
 import { FloatingCreateButton } from "src/components/FloatingCreateButton";
+import { QueryErrorState } from "../components/QueryErrorState";
 import { fonts } from "../theme/fonts";
 
 export function FeedScreen() {
@@ -32,6 +33,7 @@ export function FeedScreen() {
   const {
     data: feedPosts,
     loading: loadingPosts,
+    error: feedError,
     refetch: refetchPosts,
   } = useQuery(fetchFeedPosts, [followingIds, profile?.id], { staleTime: 60_000 });
   const [refreshing, setRefreshing] = useState(false);
@@ -138,6 +140,10 @@ export function FeedScreen() {
   );
 
   const styles = createStyles(colors);
+
+  if (feedError && !feedPosts) {
+    return <QueryErrorState message={feedError} onRetry={refetchPosts} />;
+  }
 
   return (
     <View style={styles.container}>

--- a/src/screens/FollowListScreen.tsx
+++ b/src/screens/FollowListScreen.tsx
@@ -18,6 +18,7 @@ import { useQuery } from "../hooks/useQuery";
 import { getProfileById, getProfilesByIds } from "../services/users";
 import { getFollowerIds, getFollowingIds } from "../services/follows";
 import { HapticPressable } from "src/components/HapticPressable";
+import { QueryErrorState } from "../components/QueryErrorState";
 
 export function FollowListScreen() {
   const { colors } = useTheme();
@@ -55,12 +56,12 @@ export function FollowListScreen() {
     () => getFollowingIds(userId),
     [userId]
   );
-  const { data: followingUserIds, loading: loadingFollowingIds, refetch: refetchFollowingIds } =
+  const { data: followingUserIds, loading: loadingFollowingIds, error: followingError, refetch: refetchFollowingIds } =
     useQuery(fetchFollowingIds, ['following', userId]);
 
   // Fetch follower IDs for this user
   const fetchFollowerIds = useCallback(() => getFollowerIds(userId), [userId]);
-  const { data: followerUserIds, loading: loadingFollowerIds, refetch: refetchFollowerIds } =
+  const { data: followerUserIds, loading: loadingFollowerIds, error: followerError, refetch: refetchFollowerIds } =
     useQuery(fetchFollowerIds, ['followers', userId]);
 
   // Fetch following profiles
@@ -98,6 +99,17 @@ export function FollowListScreen() {
     activeTab === "following"
       ? loadingFollowingIds || loadingFollowingProfiles
       : loadingFollowerIds || loadingFollowerProfiles;
+
+  const activeError = activeTab === "following" ? followingError : followerError;
+  const activeRefetch = activeTab === "following" ? refetchFollowingIds : refetchFollowerIds;
+
+  if (activeError && listData.length === 0) {
+    return (
+      <View style={[styles.container, { paddingTop: headerHeight }]}>
+        <QueryErrorState message={activeError} onRetry={activeRefetch} />
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.container, { paddingTop: headerHeight }]}>

--- a/src/screens/GuideDetailScreen.tsx
+++ b/src/screens/GuideDetailScreen.tsx
@@ -29,6 +29,7 @@ import { getProfileById } from "../services/users";
 import { shareGuide } from "../utils/sharing";
 import { useTheme, type Colors } from "../theme/ThemeContext";
 import { fonts } from "../theme/fonts";
+import { QueryErrorState } from "../components/QueryErrorState";
 import type { PlaceCategory } from "../types";
 
 const CATEGORY_ICONS: Record<PlaceCategory, { sf: string; fallback: string }> =
@@ -57,6 +58,7 @@ export function GuideDetailScreen() {
   const {
     data: guide,
     loading: loadingGuide,
+    error: guideError,
     refetch: refetchGuide,
   } = useQuery(fetchGuide, ["guide", guideId]);
 
@@ -159,6 +161,10 @@ export function GuideDetailScreen() {
         <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
+  }
+
+  if (guideError && !guide) {
+    return <QueryErrorState message={guideError} onRetry={refetchGuide} />;
   }
 
   if (!guide) return null;

--- a/src/screens/GuidesListScreen.tsx
+++ b/src/screens/GuidesListScreen.tsx
@@ -21,6 +21,7 @@ import { useQuery } from "../hooks/useQuery";
 import { useAuth } from "../context/AuthContext";
 import { getGuidesByUserId } from "../services/guides";
 import { useTheme, type Colors } from "../theme/ThemeContext";
+import { QueryErrorState } from "../components/QueryErrorState";
 import { fonts } from "../theme/fonts";
 
 export function GuidesListScreen() {
@@ -40,7 +41,7 @@ export function GuidesListScreen() {
     () => getGuidesByUserId(userId),
     [userId]
   );
-  const { data: guides, loading, refetch } = useQuery(fetchGuides, [
+  const { data: guides, loading, error: guidesError, refetch } = useQuery(fetchGuides, [
     "guides",
     "user",
     userId,
@@ -63,6 +64,10 @@ export function GuidesListScreen() {
         <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
+  }
+
+  if (guidesError && !guides) {
+    return <QueryErrorState message={guidesError} onRetry={refetch} />;
   }
 
   return (

--- a/src/screens/HashtagDetailScreen.tsx
+++ b/src/screens/HashtagDetailScreen.tsx
@@ -11,6 +11,7 @@ import { getPlaces } from '../services/places';
 import { FeedPost } from '../components/FeedPost';
 import { formatNumber } from '../utils/formatNumber';
 import { useTheme, type Colors } from '../theme/ThemeContext';
+import { QueryErrorState } from '../components/QueryErrorState';
 import { fonts } from '../theme/fonts';
 
 export function HashtagDetailScreen() {
@@ -24,7 +25,7 @@ export function HashtagDetailScreen() {
   const styles = createStyles(colors);
 
   const fetchHashtag = useCallback(() => getHashtagByName(tag), [tag]);
-  const { data: hashtag, loading: loadingHashtag } = useQuery(fetchHashtag, ['hashtag', tag]);
+  const { data: hashtag, loading: loadingHashtag, error: hashtagError, refetch: refetchHashtag } = useQuery(fetchHashtag, ['hashtag', tag]);
 
   const fetchPostIds = useCallback(
     () => (hashtag ? getPostIdsByHashtagId(hashtag.id) : Promise.resolve([])),
@@ -100,6 +101,10 @@ export function HashtagDetailScreen() {
         <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
+  }
+
+  if (hashtagError && !hashtag) {
+    return <QueryErrorState message={hashtagError} onRetry={refetchHashtag} />;
   }
 
   return (

--- a/src/screens/LikesListScreen.tsx
+++ b/src/screens/LikesListScreen.tsx
@@ -17,6 +17,7 @@ import { useQuery } from "../hooks/useQuery";
 import { getProfilesByIds } from "../services/users";
 import { getLikerIds } from "../services/likes";
 import { HapticPressable } from "src/components/HapticPressable";
+import { QueryErrorState } from "../components/QueryErrorState";
 
 export function LikesListScreen() {
   const { colors } = useTheme();
@@ -29,7 +30,7 @@ export function LikesListScreen() {
   const { profile } = useAuth();
 
   const fetchLikerIds = useCallback(() => getLikerIds(postId), [postId]);
-  const { data: likerIds, loading: loadingIds, refetch: refetchLikerIds } = useQuery(fetchLikerIds, ['likes', postId]);
+  const { data: likerIds, loading: loadingIds, error: likesError, refetch: refetchLikerIds } = useQuery(fetchLikerIds, ['likes', postId]);
 
   const fetchProfiles = useCallback(
     () => getProfilesByIds(likerIds ?? []),
@@ -48,6 +49,10 @@ export function LikesListScreen() {
       refetchLikerIds();
     }, [refetchLikerIds])
   );
+
+  if (likesError && !likerIds) {
+    return <QueryErrorState message={likesError} onRetry={refetchLikerIds} />;
+  }
 
   return (
     <View style={styles.container}>

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -34,6 +34,7 @@ import { useRouter } from "expo-router";
 import { useTheme, type Colors } from "../theme/ThemeContext";
 import { fonts } from "../theme/fonts";
 import { FloatingCreateButton } from "src/components/FloatingCreateButton";
+import { QueryErrorState } from "../components/QueryErrorState";
 import { useMapPlaceSelection } from "../context/MapPlaceSelectionContext";
 import * as Haptics from "expo-haptics";
 
@@ -113,11 +114,13 @@ export function MapScreen() {
   const {
     places,
     trails,
+    error: mapError,
     isInitialLoad,
     filteredPlaces,
     annotatedPlaceIds,
     baseMarkerDataMap,
     placeEventsMap,
+    refetchAll,
   } = useMapData({
     followingIds,
     selectedCategories,
@@ -278,12 +281,18 @@ export function MapScreen() {
           })}
       </MapView>
 
-      {isInitialLoad && (
+      {isInitialLoad && !mapError && (
         <View style={[styles.loadingOverlay, { top: insets.top + 106 }]}>
           <BlurView intensity={15} tint={isDark ? "dark" : "light"} style={styles.loadingContainer}>
             <ActivityIndicator size="small" color={colors.primary} />
             <Text style={styles.loadingText}>Loading places...</Text>
           </BlurView>
+        </View>
+      )}
+
+      {mapError && !places && (
+        <View style={[styles.loadingOverlay, { top: insets.top + 106 }]}>
+          <QueryErrorState message={mapError} onRetry={refetchAll} fullScreen={false} />
         </View>
       )}
 

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -19,6 +19,7 @@ import { useQuery } from "../hooks/useQuery";
 import { SFIcon } from "../components/SFIcon";
 import { HapticPressable } from "../components/HapticPressable";
 import { useTheme, type Colors } from "../theme/ThemeContext";
+import { QueryErrorState } from "../components/QueryErrorState";
 import { fonts } from "../theme/fonts";
 import type { Notification } from "../services/notifications";
 
@@ -102,7 +103,7 @@ export function NotificationsScreen() {
   );
 
   const fetchActors = useCallback(() => getProfilesByIds(actorIds), [actorIds]);
-  const { data: actors, loading } = useQuery(fetchActors, actorIds);
+  const { data: actors, loading, error: actorsError } = useQuery(fetchActors, actorIds);
 
   const fetchPosts = useCallback(() => getPostsByIds(postIds), [postIds]);
   const { data: posts } = useQuery(fetchPosts, postIds);
@@ -183,6 +184,10 @@ export function NotificationsScreen() {
         />
       </View>
     );
+  }
+
+  if (actorsError && notifications.length === 0) {
+    return <QueryErrorState message={actorsError} onRetry={refetch} />;
   }
 
   return (

--- a/src/screens/PlaceDetailScreen.tsx
+++ b/src/screens/PlaceDetailScreen.tsx
@@ -22,6 +22,7 @@ import { fonts } from "../theme/fonts";
 import { HapticPressable } from 'src/components/HapticPressable';
 import { HashtagText } from '../components/HashtagText';
 import { LiquidGlassButton } from '../components/LiquidGlassButton';
+import { QueryErrorState } from '../components/QueryErrorState';
 
 const CATEGORY_LABELS: Record<PlaceCategory, string> = {
   cafe: 'Cafe',
@@ -46,7 +47,7 @@ export function PlaceDetailScreen() {
   const { isSaved, toggleSave } = useSave();
 
   const fetchPlace = useCallback(() => getPlaceById(placeId), [placeId]);
-  const { data: place, loading: loadingPlace, refetch: refetchPlace } = useQuery(fetchPlace, ['place', placeId]);
+  const { data: place, loading: loadingPlace, error: placeError, refetch: refetchPlace } = useQuery(fetchPlace, ['place', placeId]);
 
   const fetchPosts = useCallback(() => getPostsByPlaceIdAsync(placeId), [placeId]);
   const { data: posts, loading: loadingPosts, refetch: refetchPosts } = useQuery(fetchPosts, ['posts', 'place', placeId]);
@@ -109,6 +110,10 @@ export function PlaceDetailScreen() {
         <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
+  }
+
+  if (placeError && !place) {
+    return <QueryErrorState message={placeError} onRetry={refetchPlace} />;
   }
 
   if (!place) return null;

--- a/src/screens/PlacePostsSheetScreen.tsx
+++ b/src/screens/PlacePostsSheetScreen.tsx
@@ -30,6 +30,7 @@ import { fonts } from "../theme/fonts";
 import { BlurView } from "expo-blur";
 import { HashtagText } from "../components/HashtagText";
 import { useTheme, type Colors } from "../theme/ThemeContext";
+import { QueryErrorState } from "../components/QueryErrorState";
 import type { Place, PlaceCategory, Post } from "../types";
 
 const CATEGORY_LABELS: Record<PlaceCategory, string> = {
@@ -65,11 +66,13 @@ export function PlacePostsSheetScreen() {
   const {
     data: place,
     loading: placeLoading,
+    error: placeError,
     refetch: refetchPlace,
   } = useQuery(fetchPlace, ['place', placeId]);
   const {
     data: posts,
     loading: postsLoading,
+    error: postsError,
     refetch: refetchPosts,
   } = useQuery(fetchPosts, ['posts', 'place', placeId]);
   const {
@@ -162,6 +165,14 @@ export function PlacePostsSheetScreen() {
       });
     }
   }, [place]);
+
+  if ((placeError || postsError) && !place) {
+    return (
+      <View style={styles.container}>
+        <QueryErrorState message={placeError || postsError} onRetry={() => { refetchPlace(); refetchPosts(); }} />
+      </View>
+    );
+  }
 
   if (placeLoading || postsLoading || !place) {
     return (

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -31,6 +31,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { SFIcon } from "../components/SFIcon";
+import { QueryErrorState } from "../components/QueryErrorState";
 import { LinearGradient } from "expo-linear-gradient";
 import Animated from "react-native-reanimated";
 import { TapGestureHandler, State } from "react-native-gesture-handler";
@@ -100,6 +101,7 @@ export function PostDetailScreen() {
   const {
     data: post,
     loading,
+    error: postError,
     refetch: refetchPost,
   } = useQuery(fetchPost, ["post", postId]);
   const [aspectRatio, setAspectRatio] = useState<number>(16 / 9);
@@ -223,6 +225,10 @@ export function PostDetailScreen() {
         <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
+  }
+
+  if (postError && !post) {
+    return <QueryErrorState message={postError} onRetry={refetchPost} />;
   }
 
   if (!post) return null;

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -23,6 +23,7 @@ import { fonts } from "../theme/fonts";
 import { useTheme, type Colors } from "../theme/ThemeContext";
 import { useInstagramConnection } from "../hooks/useInstagramConnection";
 import { HapticPressable } from "src/components/HapticPressable";
+import { QueryErrorState } from "../components/QueryErrorState";
 
 export function ProfileScreen() {
   const { colors } = useTheme();
@@ -44,7 +45,7 @@ export function ProfileScreen() {
     () => getPostsByUserId(currentUser.id),
     [currentUser.id]
   );
-  const { data: posts, refetch: refetchPosts } = useQuery(fetchPosts, [
+  const { data: posts, error: postsError, refetch: refetchPosts } = useQuery(fetchPosts, [
     "posts",
     "user",
     currentUser.id,
@@ -133,6 +134,10 @@ export function ProfileScreen() {
   }, [events, allPlaces, placeMap]);
 
   const styles = createStyles(colors);
+
+  if (postsError && !posts) {
+    return <QueryErrorState message={postsError} onRetry={refetchPosts} />;
+  }
 
   return (
     <ScrollView

--- a/src/screens/SavedScreen.tsx
+++ b/src/screens/SavedScreen.tsx
@@ -24,6 +24,7 @@ import { SFIcon } from "../components/SFIcon";
 import { HapticPressable } from "../components/HapticPressable";
 import { useTheme, type Colors } from "../theme/ThemeContext";
 import { fonts } from "../theme/fonts";
+import { QueryErrorState } from "../components/QueryErrorState";
 import type { Place, PlaceCategory } from "../types";
 
 type Tab = "posts" | "places" | "events" | "guides";
@@ -56,7 +57,7 @@ export function SavedScreen() {
     () => getPostsByIds(savedPostIds),
     [savedPostIds]
   );
-  const { data: posts, refetch: refetchPosts } = useQuery(fetchPosts, [
+  const { data: posts, error: postsError, refetch: refetchPosts } = useQuery(fetchPosts, [
     "saved-posts",
     ...savedPostIds,
   ]);
@@ -65,7 +66,7 @@ export function SavedScreen() {
     () => getPlacesByIds(savedPlaceIds),
     [savedPlaceIds]
   );
-  const { data: places, refetch: refetchPlaces } = useQuery(fetchPlaces, [
+  const { data: places, error: placesError, refetch: refetchPlaces } = useQuery(fetchPlaces, [
     "saved-places",
     ...savedPlaceIds,
   ]);
@@ -74,7 +75,7 @@ export function SavedScreen() {
     () => getEventsByIds(savedEventIds),
     [savedEventIds]
   );
-  const { data: events, refetch: refetchEvents } = useQuery(fetchEvents, [
+  const { data: events, error: eventsError, refetch: refetchEvents } = useQuery(fetchEvents, [
     "saved-events",
     ...savedEventIds,
   ]);
@@ -83,7 +84,7 @@ export function SavedScreen() {
     () => getGuidesByIds(savedGuideIds),
     [savedGuideIds]
   );
-  const { data: savedGuides, refetch: refetchGuides } = useQuery(fetchGuides, [
+  const { data: savedGuides, error: guidesError, refetch: refetchGuides } = useQuery(fetchGuides, [
     "saved-guides",
     ...savedGuideIds,
   ]);
@@ -123,6 +124,9 @@ export function SavedScreen() {
   const renderContent = () => {
     switch (activeTab) {
       case "posts":
+        if (postsError && !posts) {
+          return <QueryErrorState message={postsError} onRetry={refetchPosts} fullScreen={false} />;
+        }
         return (
           <PostsGrid
             posts={postsWithPlaces}
@@ -132,6 +136,9 @@ export function SavedScreen() {
         );
 
       case "places":
+        if (placesError && !places) {
+          return <QueryErrorState message={placesError} onRetry={refetchPlaces} fullScreen={false} />;
+        }
         if (!places || places.length === 0) {
           return (
             <View style={styles.emptyState}>
@@ -188,6 +195,9 @@ export function SavedScreen() {
         );
 
       case "events":
+        if (eventsError && !events) {
+          return <QueryErrorState message={eventsError} onRetry={refetchEvents} fullScreen={false} />;
+        }
         if (!events || events.length === 0) {
           return (
             <View style={styles.emptyState}>
@@ -221,6 +231,9 @@ export function SavedScreen() {
         );
 
       case "guides":
+        if (guidesError && !savedGuides) {
+          return <QueryErrorState message={guidesError} onRetry={refetchGuides} fullScreen={false} />;
+        }
         if (!savedGuides || savedGuides.length === 0) {
           return (
             <View style={styles.emptyState}>

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -27,6 +27,7 @@ import { EventCard } from "../components/EventCard";
 import { GuideCard } from "../components/GuideCard";
 import { HapticPressable } from "../components/HapticPressable";
 import { getTrendingHashtags, searchHashtags } from "../services/hashtags";
+import { QueryErrorState } from "../components/QueryErrorState";
 import { formatNumber } from "../utils/formatNumber";
 import type {
   Place,
@@ -88,7 +89,7 @@ export function SearchScreen({ query = "", onQueryChange }: SearchScreenProps) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
 
-  const { data: places } = useQuery(getPlaces, "places");
+  const { data: places, error: placesError, refetch: refetchPlaces } = useQuery(getPlaces, "places");
   const { data: posts } = useQuery(getPosts, "posts");
   const { data: users } = useQuery(getProfiles, "profiles");
   const { data: events } = useQuery(getUpcomingEvents, "events");
@@ -571,6 +572,10 @@ export function SearchScreen({ query = "", onQueryChange }: SearchScreenProps) {
   };
 
   const styles = createStyles(colors);
+
+  if (placesError && !places) {
+    return <QueryErrorState message={placesError} onRetry={refetchPlaces} />;
+  }
 
   // Search results view
   if (query.trim()) {

--- a/src/screens/TrailDetailSheetScreen.tsx
+++ b/src/screens/TrailDetailSheetScreen.tsx
@@ -26,6 +26,7 @@ import { getProfileById } from "../services/users";
 import { sortPosts } from "../utils/postSorting";
 import { fonts } from "../theme/fonts";
 import { useTheme, type Colors } from "../theme/ThemeContext";
+import { QueryErrorState } from "../components/QueryErrorState";
 import type { TrailDifficulty, Post } from "../types";
 
 const DIFFICULTY_LABELS: Record<TrailDifficulty, string> = {
@@ -48,7 +49,7 @@ export function TrailDetailSheetScreen() {
   const { getLikeCount } = useLike();
 
   const fetchTrail = useCallback(() => getTrailById(trailId ?? ""), [trailId]);
-  const { data: trail, loading } = useQuery(fetchTrail, ["trail", trailId]);
+  const { data: trail, loading, error: trailError, refetch: refetchTrail } = useQuery(fetchTrail, ["trail", trailId]);
 
   // Fetch posts for the trail's shadow place
   const fetchPosts = useCallback(
@@ -108,7 +109,7 @@ export function TrailDetailSheetScreen() {
     [posts, getLikeCount]
   );
 
-  if (loading || !trail) {
+  if (loading && !trail) {
     return (
       <View style={styles.container}>
         <View style={styles.loading}>
@@ -117,6 +118,16 @@ export function TrailDetailSheetScreen() {
       </View>
     );
   }
+
+  if (trailError && !trail) {
+    return (
+      <View style={styles.container}>
+        <QueryErrorState message={trailError} onRetry={refetchTrail} />
+      </View>
+    );
+  }
+
+  if (!trail) return null;
 
   const trailColor = colors.category.trail;
 

--- a/src/screens/UserProfileScreen.tsx
+++ b/src/screens/UserProfileScreen.tsx
@@ -27,6 +27,7 @@ import { UpcomingEvents } from "../components/UpcomingEvents";
 import { fonts } from "../theme/fonts";
 import { useTheme, type Colors } from "../theme/ThemeContext";
 import { HapticPressable } from "src/components/HapticPressable";
+import { QueryErrorState } from "../components/QueryErrorState";
 
 export function UserProfileScreen() {
   const { colors } = useTheme();
@@ -59,7 +60,7 @@ export function UserProfileScreen() {
   }, [avatarAnim]);
 
   const fetchUser = useCallback(() => getProfileById(userId), [userId]);
-  const { data: user, loading: loadingUser, refetch: refetchUser } = useQuery(fetchUser, ['user', userId]);
+  const { data: user, loading: loadingUser, error: userError, refetch: refetchUser } = useQuery(fetchUser, ['user', userId]);
 
   const fetchPosts = useCallback(() => getPostsByUserIdAsync(userId), [userId]);
   const { data: posts, refetch: refetchPosts } = useQuery(fetchPosts, ['posts', 'user', userId]);
@@ -120,6 +121,10 @@ export function UserProfileScreen() {
         <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
+  }
+
+  if (userError && !user) {
+    return <QueryErrorState message={userError} onRetry={refetchUser} />;
   }
 
   if (!user) return null;


### PR DESCRIPTION
## Summary
- Install `@react-native-community/netinfo` and wire to React Query's `onlineManager` with `networkMode: 'offlineFirst'` so queries serve cached data when offline and auto-pause refetches
- Add `NetworkProvider` context, animated `OfflineBanner` (slides down with wifi.slash icon), and reusable `QueryErrorState` component that adapts messaging for offline vs error states
- Surface errors on all 19 data-fetching screens using `error && !data` guard pattern (stale cached data still shown when available)
- Replace silent `.catch(() => {})` in FollowContext, LikeContext, SaveContext, and NotificationContext with `console.warn` for debuggability

### New files
| File | Purpose |
|------|---------|
| `src/lib/networkManager.ts` | Wires NetInfo to React Query onlineManager |
| `src/context/NetworkContext.tsx` | `NetworkProvider` + `useNetwork()` hook |
| `src/components/OfflineBanner.tsx` | Animated offline banner |
| `src/components/QueryErrorState.tsx` | Reusable error/offline state with retry |

### Modified files (28)
- `app/_layout.tsx` — setup network manager, add providers + banner
- `src/lib/queryClient.ts` — `networkMode: 'offlineFirst'`
- `src/hooks/useMapData.ts` — expose aggregated error + refetchAll
- 19 screen files — add QueryErrorState error handling
- 4 context files — replace silent catches with console.warn

Closes #29, closes #24

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm test` passes (69 tests)
- [ ] Toggle airplane mode on simulator → offline banner slides down, screens show "You're offline" with retry button
- [ ] Turn off airplane mode → banner dismisses, retry works
- [ ] Kill Supabase connection → screens show error state with "Try Again" button
- [ ] Screens with cached data still show stale content when errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)