### PR TITLE
feat: configure expo-updates for OTA updates

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -9,6 +9,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     name: "Welly",
     slug: "wellington-app",
     version: "1.0.0",
+    runtimeVersion: {
+      policy: "appVersion",
+    },
     scheme: "wellington",
     orientation: "portrait",
     icon: "./assets/icon.png",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,6 +30,7 @@ import { ExplorationProvider } from "../src/context/ExplorationContext";
 import { LocationProvider } from "../src/context/LocationContext";
 import { ZoomOverlayProvider } from "../src/context/ZoomOverlayContext";
 import { StatusBar } from "expo-status-bar";
+import { useOTAUpdates } from "../src/hooks/useOTAUpdates";
 
 export function ErrorBoundary({ error, retry }: { error: Error; retry: () => void }) {
   return <ErrorScreen error={error} retry={retry} />;
@@ -202,6 +203,8 @@ function AuthGate({ children }: { children: React.ReactNode }) {
 }
 
 export default function RootLayout() {
+  useOTAUpdates();
+
   const [fontsLoaded] = useFonts({
     PlusJakartaSans_500Medium,
     PlusJakartaSans_600SemiBold,

--- a/src/hooks/useOTAUpdates.ts
+++ b/src/hooks/useOTAUpdates.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { Alert, AppState } from "react-native";
+import * as Updates from "expo-updates";
+
+export function useOTAUpdates() {
+  useEffect(() => {
+    if (__DEV__) return;
+
+    async function checkForUpdate() {
+      try {
+        const update = await Updates.checkForUpdateAsync();
+        if (update.isAvailable) {
+          await Updates.fetchUpdateAsync();
+          Alert.alert(
+            "Update Available",
+            "A new version has been downloaded. Restart now to apply it?",
+            [
+              { text: "Later", style: "cancel" },
+              { text: "Restart", onPress: () => Updates.reloadAsync() },
+            ]
+          );
+        }
+      } catch {
+        // Silently ignore update check failures
+      }
+    }
+
+    // Check on mount
+    checkForUpdate();
+
+    // Check when app returns to foreground
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        checkForUpdate();
+      }
+    });
+
+    return () => subscription.remove();
+  }, []);
+}


### PR DESCRIPTION
## Summary
- Add `runtimeVersion: { policy: "appVersion" }` to `app.config.ts` so OTA updates are tied to the app version
- Create `useOTAUpdates` hook that checks for updates on mount and app foreground, then prompts users to restart
- Wire up the hook in the root layout for global update checking

Closes #23

## Test plan
- [ ] Run `npx expo config --type public` and verify `runtimeVersion` appears
- [ ] Build a preview/production build and verify update checking runs without errors
- [ ] Publish an update with `eas update` and confirm the app detects and applies it

🤖 Generated with [Claude Code](https://claude.com/claude-code)