### PR TITLE
feat: add report content flow

### DIFF
--- a/src/hooks/useReport.ts
+++ b/src/hooks/useReport.ts
@@ -1,0 +1,78 @@
+import { Alert, Platform } from 'react-native';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+import { createReport } from '../services/reports';
+import type { ReportContentType, ReportReason } from '../types';
+
+interface ReportTarget {
+  contentType: ReportContentType;
+  contentId?: string;
+  reportedUserId: string;
+}
+
+export function useReport() {
+  const { profile } = useAuth();
+  const { showToast } = useToast();
+
+  const submitReport = async (target: ReportTarget, reason: ReportReason, details?: string) => {
+    if (!profile) return;
+    try {
+      await createReport({
+        reporterId: profile.id,
+        reportedUserId: target.reportedUserId,
+        contentType: target.contentType,
+        contentId: target.contentId,
+        reason,
+        details,
+      });
+      showToast({ message: 'Report submitted' });
+    } catch (err: any) {
+      if (err?.code === '23505') {
+        showToast({ message: 'You already reported this', type: 'error' });
+      } else {
+        showToast({ message: 'Failed to submit report', type: 'error' });
+      }
+    }
+  };
+
+  const showReportAlert = (target: ReportTarget) => {
+    Alert.alert('Report', 'Why are you reporting this?', [
+      {
+        text: 'Spam',
+        onPress: () => submitReport(target, 'spam'),
+      },
+      {
+        text: 'Inappropriate',
+        onPress: () => submitReport(target, 'inappropriate'),
+      },
+      {
+        text: 'Harassment',
+        onPress: () => submitReport(target, 'harassment'),
+      },
+      {
+        text: 'Other',
+        onPress: () => {
+          if (Platform.OS === 'ios') {
+            Alert.prompt(
+              'Report',
+              'Please provide details (optional)',
+              [
+                { text: 'Cancel', style: 'cancel' },
+                {
+                  text: 'Submit',
+                  onPress: (text?: string) => submitReport(target, 'other', text || undefined),
+                },
+              ],
+              'plain-text',
+            );
+          } else {
+            submitReport(target, 'other');
+          }
+        },
+      },
+      { text: 'Cancel', style: 'cancel' },
+    ]);
+  };
+
+  return { showReportAlert };
+}

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -64,6 +64,7 @@ import { createCommentNotification } from "../services/notifications";
 import { ContextMenu, Button as ExpoButton, Host } from "@expo/ui/swift-ui";
 import { HapticPressable } from "src/components/HapticPressable";
 import { HashtagText } from "../components/HashtagText";
+import { useReport } from "../hooks/useReport";
 
 function formatTimeAgo(dateString: string): string {
   const date = new Date(dateString);
@@ -116,9 +117,10 @@ export function PostDetailScreen() {
   const isOwnPost = post?.userId === profile?.id;
   const onEditRef = useRef<(() => void) | undefined>(undefined);
   const onDeleteRef = useRef<(() => void) | undefined>(undefined);
+  const onReportRef = useRef<(() => void) | undefined>(undefined);
+  const { showReportAlert } = useReport();
 
   useLayoutEffect(() => {
-    if (!isOwnPost) return;
     navigation.setOptions({
       headerRight: () => (
         <Host matchContents>
@@ -140,19 +142,31 @@ export function PostDetailScreen() {
               </View>
             </ContextMenu.Trigger>
             <ContextMenu.Items>
-              <ExpoButton
-                systemImage="pencil"
-                onPress={() => onEditRef.current?.()}
-              >
-                Edit caption
-              </ExpoButton>
-              <ExpoButton
-                systemImage="trash"
-                role="destructive"
-                onPress={() => onDeleteRef.current?.()}
-              >
-                Delete post
-              </ExpoButton>
+              {isOwnPost ? (
+                <>
+                  <ExpoButton
+                    systemImage="pencil"
+                    onPress={() => onEditRef.current?.()}
+                  >
+                    Edit caption
+                  </ExpoButton>
+                  <ExpoButton
+                    systemImage="trash"
+                    role="destructive"
+                    onPress={() => onDeleteRef.current?.()}
+                  >
+                    Delete post
+                  </ExpoButton>
+                </>
+              ) : (
+                <ExpoButton
+                  systemImage="flag"
+                  role="destructive"
+                  onPress={() => onReportRef.current?.()}
+                >
+                  Report
+                </ExpoButton>
+              )}
             </ContextMenu.Items>
           </ContextMenu>
         </Host>
@@ -301,6 +315,14 @@ export function PostDetailScreen() {
   onEditRef.current = () => {
     setEditContent(post.content);
     setEditModalVisible(true);
+  };
+
+  onReportRef.current = () => {
+    showReportAlert({
+      contentType: 'post',
+      contentId: post.id,
+      reportedUserId: post.userId,
+    });
   };
 
   onDeleteRef.current = () => {

--- a/src/screens/UserProfileScreen.tsx
+++ b/src/screens/UserProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -10,7 +10,7 @@ import {
   Animated,
 } from "react-native";
 import { Image } from "expo-image";
-import { useRouter, useLocalSearchParams, usePathname, useFocusEffect } from "expo-router";
+import { useRouter, useLocalSearchParams, usePathname, useFocusEffect, useNavigation } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { useQuery } from "../hooks/useQuery";
@@ -28,15 +28,62 @@ import { fonts } from "../theme/fonts";
 import { useTheme, type Colors } from "../theme/ThemeContext";
 import { HapticPressable } from "src/components/HapticPressable";
 import { QueryErrorState } from "../components/QueryErrorState";
+import { useAuth } from "../context/AuthContext";
+import { useReport } from "../hooks/useReport";
+import { SFIcon } from "../components/SFIcon";
+import { ContextMenu, Button as ExpoButton, Host } from "@expo/ui/swift-ui";
 
 export function UserProfileScreen() {
   const { colors } = useTheme();
   const router = useRouter();
+  const navigation = useNavigation();
   const { userId } = useLocalSearchParams<{ userId: string }>();
   const pathname = usePathname();
   const tabBase = "/" + pathname.split("/")[1];
   const insets = useSafeAreaInsets();
   const headerHeight = useHeaderHeight();
+  const { profile } = useAuth();
+  const { showReportAlert } = useReport();
+  const onReportRef = useRef<(() => void) | undefined>(undefined);
+
+  const isOtherUser = profile?.id !== userId;
+
+  useLayoutEffect(() => {
+    if (!isOtherUser) return;
+    navigation.setOptions({
+      headerRight: () => (
+        <Host matchContents>
+          <ContextMenu activationMethod="singlePress">
+            <ContextMenu.Trigger>
+              <View
+                style={{
+                  alignItems: "center",
+                  justifyContent: "center",
+                  paddingHorizontal: 7,
+                }}
+              >
+                <SFIcon
+                  name="ellipsis"
+                  fallback="ellipsis-horizontal"
+                  size={22}
+                  color={colors.text}
+                />
+              </View>
+            </ContextMenu.Trigger>
+            <ContextMenu.Items>
+              <ExpoButton
+                systemImage="flag"
+                role="destructive"
+                onPress={() => onReportRef.current?.()}
+              >
+                Report user
+              </ExpoButton>
+            </ContextMenu.Items>
+          </ContextMenu>
+        </Host>
+      ),
+    });
+  }, [navigation, isOtherUser]);
 
   const [refreshing, setRefreshing] = useState(false);
   const [avatarVisible, setAvatarVisible] = useState(false);
@@ -128,6 +175,14 @@ export function UserProfileScreen() {
   }
 
   if (!user) return null;
+
+  onReportRef.current = () => {
+    showReportAlert({
+      contentType: 'user',
+      contentId: undefined,
+      reportedUserId: userId,
+    });
+  };
 
   const followerCount = counts?.followers ?? 0;
   const followingCount = counts?.following ?? 0;

--- a/src/services/reports.ts
+++ b/src/services/reports.ts
@@ -1,0 +1,22 @@
+import { supabase } from '../lib/supabase';
+import type { ReportContentType, ReportReason } from '../types';
+
+export async function createReport(params: {
+  reporterId: string;
+  reportedUserId: string;
+  contentType: ReportContentType;
+  contentId?: string;
+  reason: ReportReason;
+  details?: string;
+}): Promise<void> {
+  const { error } = await supabase.from('reports' as any).insert({
+    reporter_id: params.reporterId,
+    reported_user_id: params.reportedUserId,
+    content_type: params.contentType,
+    content_id: params.contentId ?? null,
+    reason: params.reason,
+    details: params.details ?? null,
+  });
+
+  if (error) throw error;
+}

--- a/src/types/Report.ts
+++ b/src/types/Report.ts
@@ -1,0 +1,19 @@
+export type ReportReason = 'spam' | 'inappropriate' | 'harassment' | 'other';
+
+export type ReportContentType = 'post' | 'user' | 'comment';
+
+export type ReportStatus = 'pending' | 'reviewed' | 'dismissed';
+
+export interface Report {
+  id: string;
+  reporterId: string;
+  reportedUserId: string;
+  contentType: ReportContentType;
+  contentId?: string;
+  reason: ReportReason;
+  details?: string;
+  status: ReportStatus;
+  adminNotes?: string;
+  resolvedAt?: string;
+  createdAt: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './AI';
 export * from './Hashtag';
 export * from './Guide';
 export * from './Feed';
+export * from './Report';

--- a/supabase/migrations/20260226000000_add_reports.sql
+++ b/supabase/migrations/20260226000000_add_reports.sql
@@ -1,0 +1,51 @@
+-- Reports table for content moderation
+CREATE TABLE reports (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  reported_user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  content_type text NOT NULL CHECK (content_type IN ('post', 'user', 'comment')),
+  content_id uuid,
+  reason text NOT NULL CHECK (reason IN ('spam', 'inappropriate', 'harassment', 'other')),
+  details text,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'reviewed', 'dismissed')),
+  admin_notes text,
+  resolved_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Prevent duplicate reports on the same content by the same user
+CREATE UNIQUE INDEX reports_unique_post ON reports(reporter_id, content_type, content_id)
+  WHERE content_type IN ('post', 'comment') AND content_id IS NOT NULL;
+CREATE UNIQUE INDEX reports_unique_user ON reports(reporter_id, reported_user_id)
+  WHERE content_type = 'user';
+
+CREATE INDEX reports_status_idx ON reports(status);
+CREATE INDEX reports_reported_user_idx ON reports(reported_user_id);
+
+-- RLS
+ALTER TABLE reports ENABLE ROW LEVEL SECURITY;
+
+-- Users can insert their own reports
+CREATE POLICY "Users can create own reports"
+  ON reports FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = reporter_id);
+
+-- Users can view their own reports
+CREATE POLICY "Users can view own reports"
+  ON reports FOR SELECT TO authenticated
+  USING (auth.uid() = reporter_id);
+
+-- Admins can view all reports
+CREATE POLICY "Admins can view all reports"
+  ON reports FOR SELECT TO authenticated
+  USING (public.is_admin());
+
+-- Admins can update reports (change status, add notes)
+CREATE POLICY "Admins can update reports"
+  ON reports FOR UPDATE TO authenticated
+  USING (public.is_admin());
+
+-- Admins can delete reports
+CREATE POLICY "Admins can delete reports"
+  ON reports FOR DELETE TO authenticated
+  USING (public.is_admin());


### PR DESCRIPTION
## Summary
- Add `reports` table with RLS policies (users can insert/view own, admins have full access) and unique indexes to prevent duplicate reports
- Add report flow in mobile app: three-dot menu on posts (Report option for other users' posts) and user profiles (Report user option) using native Alert dialogs with reason selection
- New `useReport` hook, `Report` types, and `createReport` service

## Admin website (separate repo)
- Reports page with status/reason filters, search, review dialog with admin notes
- Server actions for updating report status, deleting reports, and deleting reported content
- "Pending Reports" count on dashboard, "Reports" nav item in sidebar

## Test plan
- [ ] Open a post by another user, tap three-dot menu, verify "Report" appears
- [ ] Submit a report, verify toast confirmation
- [ ] Try reporting the same content twice — verify duplicate error toast
- [ ] Open another user's profile, tap three-dot menu, verify "Report user" appears
- [ ] Verify own posts still show Edit/Delete in the menu
- [ ] On admin website: verify Reports page lists reports with filters and status updates work

🤖 Generated with [Claude Code](https://claude.com/claude-code)